### PR TITLE
Allow syslog messages to arrive out of order

### DIFF
--- a/syslog.t
+++ b/syslog.t
@@ -220,7 +220,7 @@ http_get('/if/work?logme=yes');
 
 get_syslog('/a');
 
-like($t->read_file('s_if.log'), qr/good:404.*work:404/s, 'syslog if success');
+like($t->read_file('s_if.log'), qr/(good:404.*work:404)|(work:404.*good:404)/s, 'syslog if success');
 unlike($t->read_file('s_if.log'), qr/(if:|empty:|zero:)404/, 'syslog if fail');
 
 like(get_syslog('/nohostname'),


### PR DESCRIPTION
I see test flakes due to the order dependency.