### PR TITLE
Portability: use `uname -n` instead of `hostname`.

### DIFF
--- a/mail_error_log.t
+++ b/mail_error_log.t
@@ -13,6 +13,7 @@ use strict;
 use Test::More;
 
 use IO::Select;
+use Sys::Hostname;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
@@ -233,8 +234,7 @@ SKIP: {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `uname -n`);
-	is($host , $hostname, "$desc valid host");
+	is($host, lc(hostname()), "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");
 	like($tag, qr'\w+', "$desc valid tag");

--- a/mail_error_log.t
+++ b/mail_error_log.t
@@ -233,7 +233,7 @@ SKIP: {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `hostname`);
+	chomp(my $hostname = lc `uname -n`);
 	is($host , $hostname, "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");

--- a/stream_access_log.t
+++ b/stream_access_log.t
@@ -158,7 +158,7 @@ is($t->read_file('filtered.log'), "127.0.0.1\n", 'log filtering');
 ok($t->read_file('complex.log'), 'if with complex value');
 ok($t->read_file('varlog_3.log'), 'variable in file');
 
-chomp(my $hostname = lc `hostname`);
+chomp(my $hostname = lc `uname -n`);
 like($t->read_file('vars.log'), qr/^\d+:[\d.]+:$hostname:\d+$/, 'log vars');
 is($t->read_file('addr.log'),
 	"$escaped:$lhost:$lport:127.0.0.1:$dport:127.0.0.1:$uport\n",

--- a/stream_access_log.t
+++ b/stream_access_log.t
@@ -12,6 +12,8 @@ use strict;
 
 use Test::More;
 
+use Sys::Hostname;
+
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -158,7 +160,7 @@ is($t->read_file('filtered.log'), "127.0.0.1\n", 'log filtering');
 ok($t->read_file('complex.log'), 'if with complex value');
 ok($t->read_file('varlog_3.log'), 'variable in file');
 
-chomp(my $hostname = lc `uname -n`);
+my $hostname = lc hostname();
 like($t->read_file('vars.log'), qr/^\d+:[\d.]+:$hostname:\d+$/, 'log vars');
 is($t->read_file('addr.log'),
 	"$escaped:$lhost:$lport:127.0.0.1:$dport:127.0.0.1:$uport\n",

--- a/stream_error_log.t
+++ b/stream_error_log.t
@@ -13,6 +13,7 @@ use strict;
 use Test::More;
 
 use IO::Select;
+use Sys::Hostname;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
@@ -241,8 +242,7 @@ SKIP: {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `uname -n`);
-	is($host , $hostname, "$desc valid host");
+	is($host, lc(hostname()), "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");
 	like($tag, qr'\w+', "$desc valid tag");

--- a/stream_error_log.t
+++ b/stream_error_log.t
@@ -241,7 +241,7 @@ SKIP: {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `hostname`);
+	chomp(my $hostname = lc `uname -n`);
 	is($host , $hostname, "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");

--- a/stream_variables.t
+++ b/stream_variables.t
@@ -80,7 +80,7 @@ $t->try_run('no inet6 support')->plan(8);
 
 ###############################################################################
 
-chomp(my $hostname = lc `hostname`);
+chomp(my $hostname = lc `uname -n`);
 like(stream('127.0.0.1:' . port(8080))->read(),
 	qr/^\d+:[\d.]+:$hostname:\d+:0$/, 'vars');
 

--- a/stream_variables.t
+++ b/stream_variables.t
@@ -12,6 +12,8 @@ use strict;
 
 use Test::More;
 
+use Sys::Hostname;
+
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -80,7 +82,7 @@ $t->try_run('no inet6 support')->plan(8);
 
 ###############################################################################
 
-chomp(my $hostname = lc `uname -n`);
+my $hostname = lc hostname();
 like(stream('127.0.0.1:' . port(8080))->read(),
 	qr/^\d+:[\d.]+:$hostname:\d+:0$/, 'vars');
 

--- a/syslog.t
+++ b/syslog.t
@@ -321,7 +321,7 @@ sub parse_syslog_message {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `hostname`);
+	chomp(my $hostname = lc `uname -n`);
 	is($host , $hostname, "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");

--- a/syslog.t
+++ b/syslog.t
@@ -13,6 +13,7 @@ use strict;
 use Test::More;
 
 use IO::Select;
+use Sys::Hostname;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
@@ -321,8 +322,7 @@ sub parse_syslog_message {
 	ok($sec < 60, "$desc valid seconds");
 
 	ok(defined($host), "$desc has host");
-	chomp(my $hostname = lc `uname -n`);
-	is($host , $hostname, "$desc valid host");
+	is($host, lc(hostname()), "$desc valid host");
 
 	ok(defined($tag), "$desc has tag");
 	like($tag, qr'\w+', "$desc valid tag");


### PR DESCRIPTION
As `hostname` is not defined by POSIX and not available by default on some modern Linux distro's (Arch, Fedora), making these tests fail.  Using `uname -n` instead fixes this in a portable way.