### PR TITLE
SSL: added AWS-LC SSL library testing support

### DIFF
--- a/h3_ssl_early_data.t
+++ b/h3_ssl_early_data.t
@@ -89,6 +89,7 @@ $s = Test::Nginx::HTTP3->new(8980, psk_list => $psk_list, early_data => {});
 TODO: {
 local $TODO = 'no 0-RTT in OpenSSL compat layer'
 	unless $t->has_module('OpenSSL [.0-9]+\+quic')
+	or $t->has_module('AWS-LC')
 	or $t->has_module('BoringSSL')
 	or $t->has_module('LibreSSL');
 

--- a/h3_ssl_session_reuse.t
+++ b/h3_ssl_session_reuse.t
@@ -139,6 +139,8 @@ is(test_reuse(8944), 1, 'tickets and cache reused');
 
 local $TODO = 'no TLSv1.3 session cache in BoringSSL'
 	if $t->has_module('BoringSSL');
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC');
 
 is(test_reuse(8945), 1, 'cache shared reused');
 is(test_reuse(8946), 1, 'cache builtin reused');

--- a/mail_ssl_session_reuse.t
+++ b/mail_ssl_session_reuse.t
@@ -147,6 +147,8 @@ is(test_reuse(8994), 1, 'tickets and cache reused');
 TODO: {
 local $TODO = 'no TLSv1.3 session cache in BoringSSL'
 	if $t->has_module('BoringSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 is(test_reuse(8995), 1, 'cache shared reused');
 is(test_reuse(8996), 1, 'cache builtin reused');

--- a/ssl.t
+++ b/ssl.t
@@ -218,6 +218,8 @@ local $TODO = 'no TLSv1.3 sessions in LibreSSL'
 	if $t->has_module('LibreSSL') && test_tls13();
 local $TODO = 'no TLSv1.3 sessions ids in BoringSSL'
 	if $t->has_module('BoringSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 sessions ids in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 like(get('/id', 8085, $ctx), qr/^body \w{64}$/m, 'session id reused');
 
@@ -229,6 +231,7 @@ like(get('/cipher', 8085), qr/^body [\w-]+$/m, 'cipher');
 
 SKIP: {
 skip 'BoringSSL', 1 if $t->has_module('BoringSSL');
+skip 'AWS-LC', 1 if $t->has_module('AWS-LC');
 
 like(get('/ciphers', 8085), qr/^body [:\w-]+$/m, 'ciphers');
 

--- a/ssl_ocsp.t
+++ b/ssl_ocsp.t
@@ -363,6 +363,8 @@ local $TODO = 'no TLSv1.3 sessions, old IO::Socket::SSL'
 	if $IO::Socket::SSL::VERSION < 2.061 && test_tls13();
 local $TODO = 'no TLSv1.3 sessions in LibreSSL'
 	if $t->has_module('LibreSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 like(get('ec-end', ses => $s),
 	qr/200 OK.*SUCCESS:r/s, 'session reused');
@@ -395,6 +397,8 @@ local $TODO = 'no TLSv1.3 sessions, old IO::Socket::SSL'
 	if $IO::Socket::SSL::VERSION < 2.061 && test_tls13();
 local $TODO = 'no TLSv1.3 sessions in LibreSSL'
 	if $t->has_module('LibreSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 like(get('ec-end', ses => $s),
 	qr/400 Bad.*FAILED:certificate revoked:r/s, 'session reused - revoked');

--- a/ssl_session_reuse.t
+++ b/ssl_session_reuse.t
@@ -174,6 +174,8 @@ is(test_reuse(8444), 1, 'tickets and cache reused');
 TODO: {
 local $TODO = 'no TLSv1.3 session cache in BoringSSL'
 	if $t->has_module('BoringSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 is(test_reuse(8445), 1, 'cache shared reused');
 is(test_reuse(8446), 1, 'cache builtin reused');

--- a/ssl_sni_sessions.t
+++ b/ssl_sni_sessions.t
@@ -118,6 +118,8 @@ plan(skip_all => 'no TLSv1.3 sessions in LibreSSL')
 	if $t->has_module('LibreSSL') && test_tls13();
 plan(skip_all => 'no TLS 1.3 session cache in BoringSSL')
 	if $t->has_module('BoringSSL') && test_tls13();
+plan(skip_all => 'no TLS 1.3 session cache in AWS-LC')
+	if $t->has_module('AWS-LC') && test_tls13();
 
 $t->plan(6);
 

--- a/stream_ssl_session_reuse.t
+++ b/stream_ssl_session_reuse.t
@@ -151,6 +151,8 @@ is(test_reuse(8444), 1, 'tickets and cache reused');
 TODO: {
 local $TODO = 'no TLSv1.3 session cache in BoringSSL'
 	if $t->has_module('BoringSSL') && test_tls13();
+local $TODO = 'no TLSv1.3 session cache in AWS-LC'
+	if $t->has_module('AWS-LC') && test_tls13();
 
 is(test_reuse(8445), 1, 'cache shared reused');
 is(test_reuse(8446), 1, 'cache builtin reused');


### PR DESCRIPTION
Closes nginx/nginx#185

This PR adds AWS-LC SSL library testing support for nginx-tests.

Related: nginx/nginx#194