### PR TITLE
Tests: mail: smtp: assert whether backend authentication is expected

### DIFF
--- a/mail_proxy_protocol.t
+++ b/mail_proxy_protocol.t
@@ -91,7 +91,7 @@ http {
 
 EOF
 
-$t->run_daemon(\&Test::Nginx::SMTP::smtp_test_daemon);
+$t->run_daemon(\&Test::Nginx::SMTP::smtp_test_daemon, port(8026), 1);
 $t->run()->plan(8);
 
 $t->waitforsocket('127.0.0.1:' . port(8026));

--- a/mail_proxy_smtp_auth.t
+++ b/mail_proxy_smtp_auth.t
@@ -75,7 +75,7 @@ http {
 
 EOF
 
-$t->run_daemon(\&Test::Nginx::SMTP::smtp_test_daemon);
+$t->run_daemon(\&Test::Nginx::SMTP::smtp_test_daemon, port(8026), 1);
 $t->run()->plan(7);
 
 $t->waitforsocket('127.0.0.1:' . port(8026));


### PR DESCRIPTION
We expect that the SMTP proxy does not authenticate to the backend, except in the `PROXY` case and in the case where `proxy_smtp_auth` is enabled.

This makes tests fail when we violate that expectation.