### PR TITLE
Tests: skip preread tests in stream_pass.t on Solaris.

### DIFF
--- a/stream_pass.t
+++ b/stream_pass.t
@@ -117,7 +117,7 @@ $t->try_run('no pass module')->plan(6);
 # passing either to HTTP or HTTPS backend, depending on server_name
 
 TODO: {
-todo_skip 'win32', 2 if $^O eq 'MSWin32';
+todo_skip 'no socket peek', 2 if $^O eq 'MSWin32' or $^O eq 'solaris';
 
 like(http_get('/'), qr/200 OK/, 'pass');
 like(http_get('/', SSL => 1, SSL_hostname => 'sni',


### PR DESCRIPTION
Similar to d3019ef, socket peek is not supported on this platform.

That's the only test currently failing on Solaris and Illumos with GNU toolchain. There are more affected platforms, but for this one I at least can build a test environment and will be running the suite regularly.

<details>
<summary>test logs</summary>

```
% uname -a
SunOS solaris-11-cbe 5.11 11.4.42.111.0 i86pc i386 i86pc kvm

# before

% prove -v tests/stream_pass.t
tests/stream_pass.t ..
1..8
not ok 1 - pass
                                                                                                                                                                                                                                                              #   Failed test 'pass'
#   at tests/stream_pass.t line 122.
#                   ''
#     doesn't match '(?^:200 OK)'
not ok 2 - pass ssl
                                                                                                                                                                                                                                                              #   Failed test 'pass ssl'
#   at tests/stream_pass.t line 123.
#                   undef
#     doesn't match '(?^:200 OK)'
ok 3 - pass ssl handshaked
ok 4 - pass with preread
ok 5 - pass variable
not ok 6 - pass with preread - log
                                                                                                                                                                                                                                                              #   Failed test 'pass with preread - log'
#   at tests/stream_pass.t line 138.
#          got: '500
# 500
# 500
# '
#     expected: '500
# '
ok 7 - no alerts
ok 8 - no sanitizer errors
# Looks like you failed 3 tests of 8.
Dubious, test returned 3 (wstat 768, 0x300)                                                                                                                                                                                                                   Failed 3/8 subtests

Test Summary Report                                                                                                                                                                                                                                           -------------------
tests/stream_pass.t (Wstat: 768 Tests: 8 Failed: 3)
  Failed tests:  1-2, 6
  Non-zero exit status: 3
Files=1, Tests=8,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.19 cusr  0.04 csys =  0.26 CPU)
Result: FAIL

# after

% prove -v tests/stream_pass.t
tests/stream_pass.t ..
1..8
not ok 1 # TODO & SKIP no socket peek
not ok 2 # TODO & SKIP no socket peek
ok 3 - pass ssl handshaked
ok 4 - pass with preread
ok 5 - pass variable
ok 6 - pass with preread - log
ok 7 - no alerts
ok 8 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=8,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.20 cusr  0.04 csys =  0.27 CPU)
Result: PASS
```

</details>