### PR TITLE
Test::Nginx: multiply timeout by TEST_NGINX_TIMEOUT_MULT env var

### DIFF
--- a/README
+++ b/README
@@ -52,4 +52,9 @@ TEST_NGINX_GLOBALS_STREAM
 
     Sets additional directives in stream context.
 
+TEST_NGINX_TIMEOUT_MULT
+
+    Applies a multiplier to timeouts used for testing. Useful when running on
+    slow systems, or with sanitizers.
+
 Happy testing!

--- a/lib/Test/Nginx.pm
+++ b/lib/Test/Nginx.pm
@@ -477,6 +477,18 @@ sub dump_config() {
 	return qx/$command 2>&1/;
 }
 
+
+sub timeout($) {
+	my ($timeout) = @_;
+	my $mult;
+	if (exists($ENV{TEST_NGINX_TIMEOUT_MULT})) {
+		$mult = $ENV{TEST_NGINX_TIMEOUT_MULT} + 0;
+	} else {
+		$mult = 1;
+	}
+	return $mult * $timeout;
+}
+
 sub waitforfile($;$) {
 	my ($self, $file, $pid) = @_;
 	my $exited;
@@ -484,7 +496,7 @@ sub waitforfile($;$) {
 	# wait for file to appear
 	# or specified process to exit
 
-	for (1 .. 50) {
+	for (1 .. timeout(50)) {
 		return 1 if -e $file;
 		return 0 if $exited;
 		$exited = waitpid($pid, WNOHANG) != 0 if $pid;
@@ -499,7 +511,7 @@ sub waitforsocket($) {
 
 	# wait for socket to accept connections
 
-	for (1 .. 50) {
+	for (1 .. timeout(50)) {
 		my $s = IO::Socket::INET->new(
 			Proto => 'tcp',
 			PeerAddr => $peer


### PR DESCRIPTION
### Proposed changes

I am developing an Nginx module which adds considerably to the startup time, especially when running with an address sanitizer. On CI machines, it needs more than the default timeout in the `waitforfile` function. I changed that subroutine to look for the environment variable `TEST_NGINX_TIMEOUT_MULT`, and multiply the iterations of the timeout loop by that number, defaulting to 1 if the variable is not defined.

My perl is bad, so please suggest improvements to my perl.

I also applied my change to the `waitforsocket` function. I'm not sure if there are any other timeouts that should be changed in addition to this one, but I'm happy to make more changes.

There are no tests for this change - I'm not sure how to go about testing it, but I'm open to suggestions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
