### PR TITLE
Add test for proxy_cache_valid with ms suffix.

### DIFF
--- a/proxy_cache_valid_subsecond.t
+++ b/proxy_cache_valid_subsecond.t
@@ -1,0 +1,88 @@
+#!/usr/bin/perl
+
+# (C) Nginx
+#
+# Tests for proxy_cache_valid with sub-second "ms" suffix.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy cache/)->plan(5)
+    ->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    proxy_cache_path %%TESTDIR%%/cache levels=1:2 keys_zone=one:1m;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://127.0.0.1:8081;
+            proxy_cache one;
+            proxy_cache_valid 200 100ms;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        location / {
+            return 200 "body\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+# First request: MISS, then HIT within 100ms
+my $r = http_get('/');
+like($r, qr/X-Cache-Status: MISS/, 'first request miss');
+
+$r = http_get('/');
+like($r, qr/X-Cache-Status: HIT/, 'second request hit');
+
+# Wait 150ms for cache to expire (100ms validity)
+select undef, undef, undef, 0.15;
+
+# Next request should see expired cache (MISS or EXPIRED)
+$r = http_get('/');
+like($r, qr/X-Cache-Status: (MISS|EXPIRED)/, 'after 150ms cache expired or miss');
+
+# Then served from upstream and cached again
+$r = http_get('/');
+like($r, qr/X-Cache-Status: HIT/, 'cached again');
+
+pass('sub-second proxy_cache_valid test completed');
+
+###############################################################################


### PR DESCRIPTION
Covers sub-second cache validity: accepts "100ms" syntax, verifies cached responses expire after the given TTL and are re-cached on next request.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Additional notes

This is in regards to https://github.com/nginx/nginx/issues/1156.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
