### PR TITLE
Adjust tests for smuggling countermeasures

### DIFF
--- a/map.t
+++ b/map.t
@@ -68,11 +68,11 @@ http {
         server_name  localhost;
 
         location / {
-            add_header X-Foo "x:$x y:$y\n";
+            add_header X-Foo "x:$x y:$y";
             return 204;
         }
         location /z {
-            add_header X-Foo "z:$z\n";
+            add_header X-Foo "z:$z";
             return 204;
         }
     }

--- a/ssl_verify_client.t
+++ b/ssl_verify_client.t
@@ -39,7 +39,6 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    add_header X-Verify x$ssl_client_verify:${ssl_client_cert}x;
     add_header X-Protocol $ssl_protocol;
 
     ssl_session_cache shared:SSL:1m;
@@ -48,6 +47,7 @@ http {
     server {
         listen       127.0.0.1:8080;
         server_name  localhost;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;
@@ -59,6 +59,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  on;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;
@@ -70,6 +71,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  optional;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;
@@ -82,6 +84,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  off;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;
@@ -94,6 +97,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  optional.no.ca;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;
@@ -105,6 +109,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  no.context;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_verify_client on;
     }
@@ -112,6 +117,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  dup;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;

--- a/ssl_verify_client_trusted.t
+++ b/ssl_verify_client_trusted.t
@@ -39,7 +39,6 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    add_header X-Verify x$ssl_client_verify:${ssl_client_cert}x;
     add_header X-Protocol $ssl_protocol;
 
     ssl_session_cache shared:SSL:1m;
@@ -48,6 +47,7 @@ http {
     server {
         listen       127.0.0.1:8443 ssl;
         server_name  trusted;
+        return 200 x$ssl_client_verify:${ssl_client_cert}x;
 
         ssl_certificate_key 1.example.com.key;
         ssl_certificate 1.example.com.crt;

--- a/worker_shutdown_timeout_proxy_upgrade.t
+++ b/worker_shutdown_timeout_proxy_upgrade.t
@@ -45,7 +45,7 @@ http {
         location / {
             proxy_pass    http://127.0.0.1:8081;
             proxy_http_version 1.1;
-            proxy_set_header Upgrade foo;
+            proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection Upgrade;
         }
     }


### PR DESCRIPTION
The tests used newlines in HTTP field values. This isn't allowed and caused garbage to be sent in responses.

### Proposed changes

Avoid relying on CRLF injection bugs in NGINX.  I have upcoming PRs that will turn these into 5xx errors.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
