### PR TITLE
Tests: added HTTP/1.x header OWS tests

### DIFF
--- a/http_header_ows.t
+++ b/http_header_ows.t
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+# Tests for HTTP/1.x optional whitespace around header field values.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use Socket qw/ CRLF /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(4)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        add_header X-Host $http_host always;
+        add_header X-Test $http_x_test always;
+
+        location / {
+            return 204;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+my $r;
+
+$r = http("GET / HTTP/1.1" . CRLF
+	. "Host:\tlocalhost" . CRLF
+	. "Connection: close" . CRLF . CRLF);
+
+like($r, qr/ 204 /, 'leading HTAB before header value');
+like($r, qr/X-Host: localhost\x0d?\x0a/, 'leading HTAB stripped');
+
+$r = http("GET / HTTP/1.1" . CRLF
+	. "Host: localhost\t" . CRLF
+	. "X-Test:\tsee-this\t" . CRLF
+	. "Connection: close" . CRLF . CRLF);
+
+like($r, qr/X-Host: localhost\x0d?\x0a/, 'trailing HTAB stripped');
+like($r, qr/X-Test: see-this\x0d?\x0a/, 'leading and trailing HTAB stripped');
+
+###############################################################################

--- a/http_header_ows.t
+++ b/http_header_ows.t
@@ -21,7 +21,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http/)->plan(4)
+my $t = Test::Nginx->new()->has(qw/http/)->plan(7)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -69,5 +69,31 @@ $r = http("GET / HTTP/1.1" . CRLF
 
 like($r, qr/X-Host: localhost\x0d?\x0a/, 'trailing HTAB stripped');
 like($r, qr/X-Test: see-this\x0d?\x0a/, 'leading and trailing HTAB stripped');
+
+###############################################################################
+
+# Transfer-Encoding and Content-Length OWS coverage.
+#
+# Tab characters around header values are HTTP/1.x OWS (RFC 9112).  After
+# OWS is stripped, Content-Length and Transfer-Encoding must be parsed
+# against the same byte stream as nginx's downstream parsers would see.
+
+like(http("GET / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Content-Length: \t0\t" . CRLF
+	. "Connection: close" . CRLF . CRLF),
+	qr/ 204 /, 'Content-Length with HTAB padding is accepted');
+
+like(http("POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Content-Length:\t0" . CRLF
+	. "Connection: close" . CRLF . CRLF),
+	qr/ 204 /, 'Content-Length with leading HTAB is accepted');
+
+like(http("GET / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding:\tchunked\t" . CRLF
+	. "Connection: close" . CRLF . CRLF),
+	qr/ 204 /, 'Transfer-Encoding chunked with HTAB padding is accepted');
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Adds a native test for HTTP/1.x optional whitespace around header field values.

The test sends headers with HTAB before and after the field value and asserts that NGINX accepts the request and exposes the trimmed value through `$http_*` variables.

The test now also covers Content-Length and Transfer-Encoding OWS handling, so leading and trailing HTAB around the field value is parsed against the same byte stream that nginx's downstream parsers would see.

## Why

This covers the behavior discussed in nginx/nginx#187 and the core patch in nginx/nginx#1404.

Current master rejects the request with `400 Bad Request`; nginx/nginx#1404 accepts it and strips the HTAB from the value.

The Content-Length and Transfer-Encoding OWS coverage was added in response to maintainer review on the related HTTP/1.x OWS thread, to close the regression sentinel pattern for runtime HTTP/1.x OWS stripping.

## Validation

Against current `nginx/nginx` master:

```text
http_header_ows.t
1..9
not ok 1 - leading HTAB before header value
not ok 2 - leading HTAB stripped
not ok 3 - trailing HTAB stripped
not ok 4 - leading and trailing HTAB stripped
not ok 5 - Content-Length with HTAB padding is accepted
not ok 6 - Transfer-Encoding chunked with leading HTAB is accepted
not ok 7 - Transfer-Encoding chunked with trailing HTAB is accepted
ok 8 - no alerts
ok 9 - no sanitizer errors
Result: FAIL
```

Against nginx/nginx#1404 (Demi:tabs-hws-h1):

```text
http_header_ows.t
1..9
ok 1 - leading HTAB before header value
ok 2 - leading HTAB stripped
ok 3 - trailing HTAB stripped
ok 4 - leading and trailing HTAB stripped
ok 5 - Content-Length with HTAB padding is accepted
ok 6 - Transfer-Encoding chunked with leading HTAB is accepted
ok 7 - Transfer-Encoding chunked with trailing HTAB is accepted
ok 8 - no alerts
ok 9 - no sanitizer errors
Result: PASS
```

## Status

Draft until the corresponding core behavior in nginx/nginx#1404 is accepted.