### PR TITLE
Tests: added HTTP/2 and HTTP/3 header OWS tests

### DIFF
--- a/h2_header_ows.t
+++ b/h2_header_ows.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# Tests for HTTP/2 optional whitespace around header field values.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::HTTP2;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_v2/)->plan(4)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    http2 on;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        add_header X-Test $http_x_test always;
+
+        location / {
+            return 204;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+my ($s, $sid, $frames, $frame);
+
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 1 },
+	{ name => 'x-test', value => "\tsee-this\t", mode => 2 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/2 header value with HTAB');
+is($frame->{headers}->{'x-test'}, 'see-this',
+	'HTTP/2 header value HTAB stripped');
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 1 },
+	{ name => 'x-test', value => " see-this ", mode => 2 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/2 header value with spaces');
+is($frame->{headers}->{'x-test'}, 'see-this',
+	'HTTP/2 header value spaces stripped');
+
+###############################################################################

--- a/h2_header_ows.t
+++ b/h2_header_ows.t
@@ -20,7 +20,7 @@ use Test::Nginx::HTTP2;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_v2/)->plan(4)
+my $t = Test::Nginx->new()->has(qw/http http_v2/)->plan(6)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -39,7 +39,8 @@ http {
         listen       127.0.0.1:8080;
         server_name  localhost;
 
-        add_header X-Test $http_x_test always;
+		add_header X-Test $http_x_test always;
+		add_header X-Test-Decorated "[$http_x_test]" always;
 
         location / {
             return 204;
@@ -81,5 +82,18 @@ $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 is($frame->{headers}->{':status'}, 204, 'HTTP/2 header value with spaces');
 is($frame->{headers}->{'x-test'}, 'see-this',
 	'HTTP/2 header value spaces stripped');
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 1 },
+	{ name => 'x-test', value => " \t ", mode => 2 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/2 whitespace-only header value');
+is($frame->{headers}->{'x-test-decorated'}, '[]',
+	'HTTP/2 whitespace-only header value stripped');
 
 ###############################################################################

--- a/h3_header_ows.t
+++ b/h3_header_ows.t
@@ -1,0 +1,105 @@
+#!/usr/bin/perl
+
+# Tests for HTTP/3 optional whitespace around header field values.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::HTTP3;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_v3 cryptx/)
+	->has_daemon('openssl')->plan(4)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_certificate_key localhost.key;
+    ssl_certificate localhost.crt;
+
+    server {
+        listen       127.0.0.1:%%PORT_8980_UDP%% quic;
+        server_name  localhost;
+
+        add_header X-Test $http_x_test always;
+
+        location / {
+            return 204;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+$t->run();
+
+###############################################################################
+
+my ($s, $sid, $frames, $frame);
+
+$s = Test::Nginx::HTTP3->new();
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 2 },
+	{ name => 'x-test', value => "\tsee-this\t", mode => 4 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/3 header value with HTAB');
+is($frame->{headers}->{'x-test'}, 'see-this',
+	'HTTP/3 header value HTAB stripped');
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 2 },
+	{ name => 'x-test', value => " see-this ", mode => 4 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/3 header value with spaces');
+is($frame->{headers}->{'x-test'}, 'see-this',
+	'HTTP/3 header value spaces stripped');
+
+###############################################################################

--- a/h3_header_ows.t
+++ b/h3_header_ows.t
@@ -21,7 +21,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http http_v3 cryptx/)
-	->has_daemon('openssl')->plan(4)
+	->has_daemon('openssl')->plan(6)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -41,7 +41,8 @@ http {
         listen       127.0.0.1:%%PORT_8980_UDP%% quic;
         server_name  localhost;
 
-        add_header X-Test $http_x_test always;
+		add_header X-Test $http_x_test always;
+		add_header X-Test-Decorated "[$http_x_test]" always;
 
         location / {
             return 204;
@@ -101,5 +102,18 @@ $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 is($frame->{headers}->{':status'}, 204, 'HTTP/3 header value with spaces');
 is($frame->{headers}->{'x-test'}, 'see-this',
 	'HTTP/3 header value spaces stripped');
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method', value => 'GET', mode => 0 },
+	{ name => ':scheme', value => 'http', mode => 0 },
+	{ name => ':path', value => '/', mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 2 },
+	{ name => 'x-test', value => " \t ", mode => 4 }]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 204, 'HTTP/3 whitespace-only header value');
+is($frame->{headers}->{'x-test-decorated'}, '[]',
+	'HTTP/3 whitespace-only header value stripped');
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Adds native HTTP/2 and HTTP/3 tests for optional whitespace around request header field values.

Each test sends `x-test` values with surrounding HTAB and SP, then verifies that the value exposed through `$http_x_test` and serialized back as `X-Test` is stripped to `see-this`.

The tests also cover a whitespace-only value by serializing `[$http_x_test]` and expecting `[]`, so the empty-string result is observable without depending on whether an empty response header is emitted.

## Why

This covers the behavior in nginx/nginx#1424, which carries the active H2/H3 reject and normalization direction. The historical lineage is nginx/nginx#1201, closed as duplicate of nginx/nginx#597 (the common helper thread).

## Validation

Built both branches with:

```sh
auto/configure --with-debug --with-http_v2_module --with-http_v3_module
make -j$(nproc)
```

Against current `nginx/nginx` master:

```text
h2_header_ows.t
1..8
ok 1 - HTTP/2 header value with HTAB
not ok 2 - HTTP/2 header value HTAB stripped
ok 3 - HTTP/2 header value with spaces
not ok 4 - HTTP/2 header value spaces stripped
ok 5 - HTTP/2 whitespace-only header value
not ok 6 - HTTP/2 whitespace-only header value stripped
ok 7 - no alerts
ok 8 - no sanitizer errors

h3_header_ows.t
1..8
ok 1 - HTTP/3 header value with HTAB
not ok 2 - HTTP/3 header value HTAB stripped
ok 3 - HTTP/3 header value with spaces
not ok 4 - HTTP/3 header value spaces stripped
ok 5 - HTTP/3 whitespace-only header value
not ok 6 - HTTP/3 whitespace-only header value stripped
ok 7 - no alerts
ok 8 - no sanitizer errors

Result: FAIL
```

Against nginx/nginx#1424:

```text
h2_header_ows.t
1..8
ok 1 - HTTP/2 header value with HTAB
ok 2 - HTTP/2 header value HTAB stripped
ok 3 - HTTP/2 header value with spaces
ok 4 - HTTP/2 header value spaces stripped
ok 5 - HTTP/2 whitespace-only header value
ok 6 - HTTP/2 whitespace-only header value stripped
ok 7 - no alerts
ok 8 - no sanitizer errors

h3_header_ows.t
1..8
ok 1 - HTTP/3 header value with HTAB
ok 2 - HTTP/3 header value HTAB stripped
ok 3 - HTTP/3 header value with spaces
ok 4 - HTTP/3 header value spaces stripped
ok 5 - HTTP/3 whitespace-only header value
ok 6 - HTTP/3 whitespace-only header value stripped
ok 7 - no alerts
ok 8 - no sanitizer errors

Result: PASS
```

## Status

Draft until the corresponding core behavior in nginx/nginx#1424 is accepted.