### PR TITLE
Tests: added add_header/add_trailer field sanitization test.

### DIFF
--- a/header_filter_sanitize.t
+++ b/header_filter_sanitize.t
@@ -20,7 +20,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(6);
+my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(12);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -45,6 +45,18 @@ http {
 
         location /resp-trailer/ {
             add_trailer X-Original-Path $uri always;
+            return 200 "ok\n";
+        }
+
+        location /bad-name-header/ {
+            add_header X-Good ok always;
+            add_header X:Bad ok always;
+            return 200 "ok\n";
+        }
+
+        location /bad-name-trailer/ {
+            add_trailer X-Good ok always;
+            add_trailer X:Bad ok always;
             return 200 "ok\n";
         }
     }
@@ -72,6 +84,20 @@ like($response, qr/X-Original-Path: \/resp-trailer\//,
     'add_trailer still emits trailer');
 unlike($response, qr/\x0d\x0aX-Injected:\s*yes/i,
     'add_trailer does not emit injected trailer header');
+
+$response = get('/bad-name-header/ok');
+like($response, qr/200 OK/, 'add_header keeps response with bad field name');
+like($response, qr/\x0d\x0aX-Good: ok\x0d\x0a/i,
+    'add_header still emits valid field');
+unlike($response, qr/\x0d\x0aX:Bad:/i,
+    'add_header skips invalid field name');
+
+$response = get('/bad-name-trailer/ok');
+like($response, qr/200 OK/, 'add_trailer keeps response with bad field name');
+like($response, qr/\x0d\x0aX-Good: ok\x0d\x0a/i,
+    'add_trailer still emits valid trailer');
+unlike($response, qr/\x0d\x0aX:Bad:/i,
+    'add_trailer skips invalid field name');
 
 ###############################################################################
 

--- a/header_filter_sanitize.t
+++ b/header_filter_sanitize.t
@@ -1,0 +1,88 @@
+#!/usr/bin/perl
+
+# Tests for sanitizing runtime-expanded add_header/add_trailer values when
+# they contain CRLF that would otherwise create new field syntax.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(6);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /resp-header/ {
+            add_header X-Original-Path $uri always;
+            return 200 "ok\n";
+        }
+
+        location /resp-trailer/ {
+            add_trailer X-Original-Path $uri always;
+            return 200 "ok\n";
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+my $crlf = '%0d%0aX-Injected:%20yes';
+my $response;
+
+$response = get('/resp-header/' . $crlf);
+like($response, qr/200 OK/, 'add_header keeps response after sanitizing CRLF');
+like($response, qr/X-Original-Path: \/resp-header\//,
+    'add_header still emits response header');
+unlike($response, qr/\x0d\x0aX-Injected:\s*yes/i,
+    'add_header does not emit injected response header');
+
+$response = get('/resp-trailer/' . $crlf);
+like($response, qr/200 OK/, 'add_trailer keeps response after sanitizing CRLF');
+like($response, qr/X-Original-Path: \/resp-trailer\//,
+    'add_trailer still emits trailer');
+unlike($response, qr/\x0d\x0aX-Injected:\s*yes/i,
+    'add_trailer does not emit injected trailer header');
+
+###############################################################################
+
+sub get {
+    my ($uri) = @_;
+    http(<<EOF);
+GET $uri HTTP/1.1
+Host: localhost
+Connection: close
+
+EOF
+}
+
+###############################################################################

--- a/header_filter_sanitize.t
+++ b/header_filter_sanitize.t
@@ -20,7 +20,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(12);
+my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(6);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -45,18 +45,6 @@ http {
 
         location /resp-trailer/ {
             add_trailer X-Original-Path $uri always;
-            return 200 "ok\n";
-        }
-
-        location /bad-name-header/ {
-            add_header X-Good ok always;
-            add_header X:Bad ok always;
-            return 200 "ok\n";
-        }
-
-        location /bad-name-trailer/ {
-            add_trailer X-Good ok always;
-            add_trailer X:Bad ok always;
             return 200 "ok\n";
         }
     }
@@ -84,20 +72,6 @@ like($response, qr/X-Original-Path: \/resp-trailer\//,
     'add_trailer still emits trailer');
 unlike($response, qr/\x0d\x0aX-Injected:\s*yes/i,
     'add_trailer does not emit injected trailer header');
-
-$response = get('/bad-name-header/ok');
-like($response, qr/200 OK/, 'add_header keeps response with bad field name');
-like($response, qr/\x0d\x0aX-Good: ok\x0d\x0a/i,
-    'add_header still emits valid field');
-unlike($response, qr/\x0d\x0aX:Bad:/i,
-    'add_header skips invalid field name');
-
-$response = get('/bad-name-trailer/ok');
-like($response, qr/200 OK/, 'add_trailer keeps response with bad field name');
-like($response, qr/\x0d\x0aX-Good: ok\x0d\x0a/i,
-    'add_trailer still emits valid trailer');
-unlike($response, qr/\x0d\x0aX:Bad:/i,
-    'add_trailer skips invalid field name');
 
 ###############################################################################
 


### PR DESCRIPTION
Summary

This is the standalone nginx-tests regression for the add_header and add_trailer value sanitization in nginx#1414.

Why

The companion test now focuses on the runtime concern worth shipping first: invalid value bytes (NUL, CR, LF) in computed add_header and add_trailer values must not produce malformed serialized fields.

Field-name validation is intentionally out of scope for this test and remains a separate config-time concern, per the maintainer direction from 2026-06-21 that field names are static and cannot be attacker-controlled, so runtime value sanitization is the concern worth shipping first.

What changed

- keeps the existing add_header/add_trailer CRLF value cases;
- asserts that the response stays 200 OK after a CRLF-bearing value reaches the response filter;
- asserts that the original header still serializes with the sanitized value;
- asserts that no injected X-Injected field line is emitted;
- keeps the usual no alerts and no sanitizer errors checks from Test::Nginx.

Patch shape

```text
1 file changed, 79 insertions(+)
```

Validation

- current nginx/nginx master: header_filter_sanitize.t fails 3/6;
- patched branch for the companion C change: header_filter_sanitize.t passes 6/6;
- ASAN/UBSAN build of the patched branch: header_filter_sanitize.t passes 6/6.

Risks / Follow-ups

This test intentionally follows the value-sanitize-only policy of nginx#1414. If upstream chooses a different late response-filter policy, the assertions should be updated to match that final design.

Field-name handling remains a separate config-time validation concern that can be added independently if maintainers prefer that boundary.