### PR TITLE
Test that unsupported 1xx responses return 500

### DIFF
--- a/fastcgi_1xx.t
+++ b/fastcgi_1xx.t
@@ -1,0 +1,105 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+
+# Test for fastcgi backend with 1xx responses.
+
+###############################################################################
+
+use warnings;
+use strict;
+use feature 'signatures';
+
+use Test::More;
+use Socket qw/ CRLF /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+eval { require FCGI; };
+plan(skip_all => 'FCGI not installed') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http fastcgi/)->plan(100)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param HTTPS $https if_not_empty;
+            fastcgi_param QUERY_STRING $query_string;
+        }
+    }
+}
+
+EOF
+
+$t->run_daemon(\&fastcgi_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+
+###############################################################################
+
+for (my $i = 100; $i < 200; ++$i) {
+        my $rsp = http(<<EOF);
+GET /$i HTTP/1.1\r
+Host: localhost\r
+Upgrade: foo\r
+Connection: close, Upgrade\r
+\r
+EOF
+        like($rsp, qr|\AHTTP/1.1 502 Bad Gateway\r\n|aa);
+}
+
+###############################################################################
+
+sub fastcgi_daemon {
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
+	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
+		$socket);
+
+	my $count;
+	while( $request->Accept() >= 0 ) {
+		$count++;
+
+		my $request_uri = $ENV{REQUEST_URI};
+                if ($request_uri !~ qr|\A/([1-5][0-9]{2})\z|aa) {
+                        print <<EOF;
+Status: 404 Not Found
+
+EOF
+                        next;
+                }
+
+		print <<EOF;
+Status: $1 Some Status
+Upgrade: foo
+Connection: upgrade
+
+EOF
+	}
+
+	FCGI::CloseSocket($socket);
+}
+
+###############################################################################

--- a/fastcgi_connect.t
+++ b/fastcgi_connect.t
@@ -1,0 +1,98 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+# (C) Demi Marie Obenour
+
+# Test for upstream handling of 2xx responses to CONNECT requests.
+
+###############################################################################
+
+use warnings;
+use strict;
+use feature 'signatures';
+
+use Test::More;
+use Socket qw/ CRLF /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+eval { require FCGI; };
+plan(skip_all => 'FCGI not installed') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http fastcgi/)->plan(1)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            if ($http_cookie != $http_cookie) {
+                # never reached
+                tunnel_pass;
+            }
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param HTTPS $https if_not_empty;
+            fastcgi_param QUERY_STRING $query_string;
+        }
+    }
+}
+
+EOF
+
+$t->run_daemon(\&fastcgi_daemon);
+$t->try_run(qw/tunnel/)->waitforsocket('127.0.0.1:' . port(8081));
+
+###############################################################################
+
+
+like(http(<<EOF), qr|\AHTTP/1.1 500 Internal Server Error\r\n|aa);
+CONNECT 255.255.255.255:1 HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+\r
+EOF
+
+###############################################################################
+
+sub fastcgi_daemon {
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
+	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
+		$socket);
+
+	my $count;
+	while( $request->Accept() >= 0 ) {
+		$count++;
+
+		my $request_uri = $ENV{REQUEST_URI};
+		print <<EOF;
+Status: 200 OK
+
+EOF
+	}
+
+	FCGI::CloseSocket($socket);
+}
+
+###############################################################################
+

--- a/proxy_upgrade.t
+++ b/proxy_upgrade.t
@@ -149,7 +149,7 @@ open my $f, '<', "$d/cc.log" or die "Can't open cc.log: $!";
 
 is($f->getline(), shift (@r) . " 540793 upgrade\n", 'log - bytes');
 is($f->getline(), shift (@r) . " 22 upgrade\n", 'log - bytes pipelined');
-like($f->getline(), qr/\d+ 0 /, 'log - bytes noupgrade');
+like($f->getline(), qr/\A\d+ \d+ close\n\z/aa, 'log - bytes noupgrade');
 
 ###############################################################################
 

--- a/ssl_proxy_upgrade.t
+++ b/ssl_proxy_upgrade.t
@@ -160,7 +160,7 @@ open my $f, '<', "$d/cc.log" or die "Can't open cc.log: $!";
 
 is($f->getline(), shift (@r) . " 540793\n", 'log - bytes');
 is($f->getline(), shift (@r) . " 22\n", 'log - bytes pipelined');
-like($f->getline(), qr/\d+ 0\n/, 'log - bytes noupgrade');
+like($f->getline(), qr/\A\d+ \d+\n\z/aa, 'log - bytes noupgrade');
 
 ###############################################################################
 


### PR DESCRIPTION
### Proposed changes

Sending a 1xx response as if it were a normal response is invalid.  With HTTP/1.x, it causes a connection desync.  With HTTP/2 and HTTP/3, it sends garbage to the client.

Test that Nginx converts these into 500 errors.  The reason for using 500 is that this is really a bug in Nginx.  Nginx should handle such responses from upstream servers correctly.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
