### PR TITLE
Tests: gzip 410 Gone responses.

### DIFF
--- a/gzip.t
+++ b/gzip.t
@@ -21,7 +21,7 @@ use Test::Nginx qw/ :DEFAULT :gzip /;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy gzip/)->plan(8);
+my $t = Test::Nginx->new()->has(qw/http proxy gzip/)->plan(11);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -48,6 +48,12 @@ http {
         location /local/ {
             gzip off;
             alias %%TESTDIR%%/;
+        }
+        location /gone {
+            gzip on;
+            gzip_types text/plain;
+            default_type text/plain;
+            return 410 "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
         }
     }
 }
@@ -80,6 +86,11 @@ unlike(http_gzip_request('/proxy/'), qr/Accept-Ranges/im,
 
 like(http_gzip_head('/'), qr/Content-Encoding: gzip/, 'gzip head');
 unlike(http_head('/'), qr/Content-Encoding: gzip/, 'no gzip head');
+
+$r = http_gzip_request('/gone');
+like($r, qr/^HTTP\/1\.1 410 Gone/m, '410 gone');
+like($r, qr/^Content-Encoding: gzip/m, 'gzip 410');
+http_gzip_like($r, qr/^X{64}\Z/, 'gzip 410 content');
 
 ###############################################################################
 


### PR DESCRIPTION
# Tests: gzip 410 Gone responses

## Proposed changes

Add test coverage for gzip compression of **410 Gone** responses. 

The gzip filter in nginx only compresses 200, 403, and 404 responses today. A companion change in [nginx/nginx](https://github.com/nginx/nginx) adds **410** to that set (see nginx/nginx#1452).

This PR extends `gzip.t` with:

- a `/gone` location that returns `410` with a 64-byte `text/plain` body
- three assertions:
  - `410 gone` — response status is 410 Gone
  - `gzip 410` — response includes `Content-Encoding: gzip`
  - `gzip 410 content` — gzipped body decodes to the expected payload

**Related issue:** https://github.com/nginx/nginx/issues/1452

**Companion nginx PR:** *(add link after opening, e.g. https://github.com/nginx/nginx/pull/XXXX)*

## Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)). *(not applicable — test-only change)*

## How to run

```bash
TEST_NGINX_BINARY=/path/to/patched/nginx/objs/nginx prove gzip.t
```

The new 410-related subtests require an nginx binary that includes the gzip 410 change from the companion PR.
