### PR TITLE
Tests: added QUERY method tests.

### DIFF
--- a/h2.t
+++ b/h2.t
@@ -25,8 +25,8 @@ use Test::Nginx::HTTP2;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_v2 proxy rewrite charset gzip/)
-	->plan(143);
+my $t = Test::Nginx->new()
+	->has(qw/http http_v2 access proxy rewrite charset gzip/)->plan(144);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -69,6 +69,13 @@ http {
         location /chunk_size {
             http2_chunk_size 1;
             return 200 'body';
+        }
+        location /query {
+            limit_except QUERY {
+                deny all;
+            }
+
+            proxy_pass http://127.0.0.1:8082/;
         }
         location /redirect {
             error_page 405 /;
@@ -317,6 +324,15 @@ $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 405, 'TRACE - not allowed');
+
+# QUERY
+
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ method => 'QUERY', path => '/query' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 200, 'QUERY');
 
 # range filter
 

--- a/h3_headers.t
+++ b/h3_headers.t
@@ -23,8 +23,9 @@ use Test::Nginx::HTTP3;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_v3 proxy rewrite cryptx/)
-	->has_daemon('openssl')->plan(75)
+my $t = Test::Nginx->new()
+	->has(qw/http http_v3 access proxy rewrite cryptx/)
+	->has_daemon('openssl')->plan(76)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -75,6 +76,14 @@ http {
             add_header X-Cookie-a $cookie_a;
             add_header X-Cookie-c $cookie_c;
             return 200;
+        }
+
+        location /query {
+            limit_except QUERY {
+                deny all;
+            }
+
+            proxy_pass http://127.0.0.1:8083/set-cookie;
         }
     }
 
@@ -144,6 +153,15 @@ $t->write_file('t2.html', 'SEE-THIS');
 ###############################################################################
 
 my ($s, $sid, $frames, $frame);
+
+# QUERY
+
+$s = Test::Nginx::HTTP3->new();
+$sid = $s->new_stream({ method => 'QUERY', path => '/query' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 200, 'QUERY');
 
 # 4.5.2. Indexed Field Line
 

--- a/query.t
+++ b/query.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc.
+
+# Tests for QUERY method.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http access proxy cache rewrite/)->plan(6)
+	->write_file_expand('nginx.conf', <<'EOF')->run();
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    proxy_cache_path %%TESTDIR%%/cache keys_zone=NAME:1m;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /method {
+            return 200 $request_method;
+        }
+
+        location /limit {
+            limit_except QUERY {
+                deny all;
+            }
+
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        location /cache {
+            proxy_pass http://127.0.0.1:8081;
+
+            proxy_cache NAME;
+            proxy_cache_methods QUERY;
+            proxy_cache_valid 1m;
+
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        return 200 $request_method;
+    }
+}
+
+EOF
+
+###############################################################################
+
+like(query('/method'), qr/^QUERY$/m, 'query method');
+like(query('/limit'), qr/ 200 /, 'query limit except');
+like(http_get('/limit'), qr/ 403 /, 'get limit except');
+like(method('OTHER', '/limit'), qr/ 403 /, 'unknown limit except');
+like(query('/cache'), qr/X-Cache-Status: MISS/, 'query cache miss');
+like(query('/cache'), qr/X-Cache-Status: HIT/, 'query cache hit');
+
+###############################################################################
+
+sub query {
+	my ($uri) = @_;
+	return method('QUERY', $uri);
+}
+
+sub method {
+	my ($method, $uri) = @_;
+	return http(<<EOF);
+$method $uri HTTP/1.1
+Host: localhost
+Connection: close
+
+EOF
+}
+
+###############################################################################


### PR DESCRIPTION
## Proposed changes

Add tests for the HTTP QUERY method over HTTP/1.x, HTTP/2, and HTTP/3.
The tests verify method recognition through `limit_except QUERY` and confirm
that QUERY responses can be cached with `proxy_cache_methods QUERY`.

Companion nginx change: https://github.com/nginx/nginx/pull/1488

## Testing

```text
TEST_NGINX_BINARY=../nginx/objs/nginx prove query.t h2.t h3_headers.t
```

All 232 checks pass.
