### PR TITLE
Tests: map regex with location captures.

### DIFF
--- a/map_capture.t
+++ b/map_capture.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc.
+
+# Tests for interaction between map module with regex and location
+# regex captures.  A map variable that uses a regex pattern must not
+# overwrite the request-level capture state ($1, $2, ...) set by the
+# location regex.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http map rewrite/)->plan(5);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    map $server_protocol $myvar {
+        ~/.+$    'mapped';
+        default  'na';
+    }
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location ~* ^/(.+)/(.+)$ {
+            return 200 "1:$1 2:$2 mv:$myvar\n";
+        }
+
+        location / {
+            return 200 "ok\n";
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/foo/bar'), qr/^1:foo 2:bar mv:mapped$/m,
+     'map regex does not overwrite location captures');
+like(http_get('/first/second'), qr/^1:first 2:second mv:mapped$/m,
+     'different URI captures preserved');
+like(http_get('/a/b'), qr/^1:a 2:b mv:mapped$/m,
+     'short URI captures preserved');
+like(http_get('/'), qr/^ok$/m,
+     'normal location unaffected');
+
+# verify captures work with static map value (not via regex)
+like(http_get('/no/map'), qr/^1:no 2:map mv:mapped$/m,
+     'captures work with map variable in response');
+
+###############################################################################


### PR DESCRIPTION
## Summary

Regression test for nginx/nginx#1573 / nginx/nginx#244: map variable with regex must not overwrite request capture state ($1, $2, ...) set by location regex.

## What the test covers

- `map` with `~/.+$` regex pattern + regex location with captures → `$1`, `$2` have correct values
- Verify captures work correctly for different URI lengths
- Verify captures work correctly for short URIs
- Verify normal location (no regex captures) unaffected
- Verify captures work when map variable is present in the response body

## Verified

All 5 subtests pass with the fix from nginx/nginx#1573. Without the fix, 4/5 fail -- `$1` and `$2` are empty and Content-Length is over-counted.

Related: nginx/nginx#244, nginx/nginx#1573
