### PR TITLE
Tests: image filter size of truncated responses

### DIFF
--- a/image_filter.t
+++ b/image_filter.t
@@ -27,7 +27,7 @@ select STDOUT; $| = 1;
 eval { require GD; };
 plan(skip_all => 'GD not installed') if $@;
 
-my $t = Test::Nginx->new()->has(qw/http proxy map image_filter/)->plan(39)
+my $t = Test::Nginx->new()->has(qw/http proxy map image_filter/)->plan(40)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -56,6 +56,10 @@ http {
         location /size {
             image_filter size;
             alias %%TESTDIR%%/;
+        }
+        location /proxy_size {
+            proxy_pass http://127.0.0.1:8081/;
+            image_filter size;
         }
 
         location /test {
@@ -195,6 +199,13 @@ like(http_get('/size/jpeg'), qr/"type": "jpeg"/, 'size jpeg');
 like(http_get('/size/gif'), qr/"type": "gif"/, 'size gif');
 like(http_get('/size/png'), qr/"type": "png"/, 'size png');
 
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.4');
+
+is(http_get_body('/proxy_size/png/16'), '{}' . CRLF, 'size truncated');
+
+}
+
 is(gif_size('/resize/gif'), '10 12', 'resize');
 is(gif_size('/resize1/gif'), '10 12', 'resize 1');
 is(gif_size('/resize2/gif'), '10 12', 'resize 2');
@@ -326,7 +337,9 @@ sub http_daemon {
 
 		next if $headers eq '';
 		$uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
-		my $data = $t->read_file($uri);
+		my ($file, $size) = $uri =~ /(\w+)\/?(\d+)?/;
+		my $data = $t->read_file($file);
+		$data = substr($data, 0, $size) if $size;
 
 		print $client <<EOF;
 HTTP/1.1 200 OK


### PR DESCRIPTION
Adds `image_filter_truncated.t`, covering `image_filter size` parsing of a
proxied response that is shorter than the fields being parsed and is sent
without `Content-Length`.

The size parser previously bounded its reads by the allocation size
(`image_filter_buffer`, used as the parse boundary when the upstream omits
`Content-Length`) rather than by the bytes actually received, so a truncated
response could cause dimensions to be read from beyond the received data. The
test asserts that a complete header still reports its dimensions, while a
16-byte body sent without `Content-Length` does not report any dimensions.

Companion to the `ngx_http_image_filter_module` source fix (nginx/nginx#1574).
