### PR TITLE
Tests: Cache-Control directive matching at token boundaries

### DIFF
--- a/http_keepalive.t
+++ b/http_keepalive.t
@@ -85,7 +85,7 @@ $t->write_file('time', '');
 $t->write_file('safari', '');
 $t->write_file('none', '');
 $t->write_file('zero', '');
-$t->run()->plan(21);
+$t->run()->plan(23);
 
 ###############################################################################
 
@@ -144,6 +144,28 @@ read_keepalive($s);
 shutdown($s, 1);
 
 ok(IO::Select->new($s)->can_read(3), 'EOF in discard body');
+
+# a connection option that merely contains a standard option as a substring
+# does not select the connection type
+
+TODO: {
+local $TODO = 'not yet';
+
+unlike(http(<<EOF), qr/Connection: close/, 'close extension');
+GET / HTTP/1.1
+Host: localhost
+Connection: x-close
+
+EOF
+
+unlike(http(<<EOF), qr/Connection: keep-alive/, 'keep-alive extension');
+GET / HTTP/1.0
+Host: localhost
+Connection: x-keep-alive
+
+EOF
+
+}
 
 $t->stop();
 

--- a/http_keepalive.t
+++ b/http_keepalive.t
@@ -85,7 +85,7 @@ $t->write_file('time', '');
 $t->write_file('safari', '');
 $t->write_file('none', '');
 $t->write_file('zero', '');
-$t->run()->plan(23);
+$t->run()->plan(25);
 
 ###############################################################################
 
@@ -144,6 +144,22 @@ read_keepalive($s);
 shutdown($s, 1);
 
 ok(IO::Select->new($s)->can_read(3), 'EOF in discard body');
+
+# HTAB is valid whitespace around list elements
+
+like(http(<<EOF), qr/Connection: close/, 'close htab');
+GET / HTTP/1.1
+Host: localhost
+Connection:\tclose
+
+EOF
+
+like(http(<<EOF), qr/Connection: close/, 'close htab after comma');
+GET / HTTP/1.1
+Host: localhost
+Connection: x-foo,\tclose
+
+EOF
 
 # a connection option that merely contains a standard option as a substring
 # does not select the connection type

--- a/proxy_cache_control.t
+++ b/proxy_cache_control.t
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy cache rewrite/)->plan(20);
+my $t = Test::Nginx->new()->has(qw/http proxy cache rewrite/)->plan(22);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -184,6 +184,16 @@ http {
             add_header Cache-control max-age=60;
             return 204;
         }
+
+        location /cache-control-extension-max-age {
+            add_header Cache-Control x-max-age=60;
+            return 204;
+        }
+
+        location /cache-control-extension-s-maxage {
+            add_header Cache-Control foo-s-maxage=60;
+            return 204;
+        }
     }
 }
 
@@ -253,6 +263,19 @@ like(get('/extension-after-x-accel-expires'),
 # Set-Cookie is considered when caching with Cache-Control
 
 like(get('/set-cookie'), qr/MISS/, 'set-cookie not cached');
+
+# extension directives that merely contain a standard directive name are
+# not treated as the standard freshness directive
+
+TODO: {
+local $TODO = 'not yet';
+
+like(get('/cache-control-extension-max-age'), qr/MISS/,
+	'cache-control extension max-age');
+like(get('/cache-control-extension-s-maxage'), qr/MISS/,
+	'cache-control extension s-maxage');
+
+}
 
 ###############################################################################
 

--- a/proxy_keepalive.t
+++ b/proxy_keepalive.t
@@ -25,7 +25,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http proxy upstream_keepalive ssi rewrite/)
-	->plan(49)->write_file_expand('nginx.conf', <<'EOF');
+	->plan(51)->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
 
@@ -206,6 +206,20 @@ like(http_get('/unbuffered/closed2'), qr/200 OK/, 'unbuffered closed 2');
 like(http_get('/inmemory/closed1'), qr/200 OK/, 'inmemory closed 1');
 like(http_get('/inmemory/closed2'), qr/200 OK/, 'inmemory closed 2');
 
+# a Connection option that merely contains "close" as a substring does not
+# prevent the upstream connection from being reused
+
+like($r = http_get('/extension1'), qr/SEE-THIS/, 'connection extension');
+$r =~ m/X-Connection: (\d+)/; $n = $1;
+
+TODO: {
+local $TODO = 'not yet';
+
+like(http_get('/extension2'), qr/X-Connection: $n/,
+	'connection extension reused');
+
+}
+
 # check for errors, shouldn't be any
 
 like(`grep -F '[error]' ${\($t->testdir())}/error.log`, qr/^$/s, 'no errors');
@@ -327,6 +341,16 @@ sub http_daemon {
 				print $client
 					"0" . CRLF . CRLF
 					unless $headers =~ /^HEAD/i;
+
+			} elsif ($uri =~ m/extension/) {
+				print $client
+					"HTTP/1.1 200 OK" . CRLF .
+					"X-Request: $rcount" . CRLF .
+					"X-Connection: $ccount" . CRLF .
+					"Connection: x-close" . CRLF .
+					"Content-Length: 26" . CRLF . CRLF;
+				print $client "TEST-OK-IF-YOU-SEE-THIS" .
+					sprintf("%03d", $ccount);
 
 			} elsif ($uri =~ m/closed/) {
 				print $client


### PR DESCRIPTION
Adds cases to `proxy_cache_control.t` verifying that extension directives which merely contain a standard directive name as a substring (`x-max-age=`, `foo-s-maxage=`) are not treated as the standard freshness directive and do not make a response cacheable.

Marked TODO until the corresponding code change is released.

Code PR: nginx/nginx#1577