### PR TITLE
Tests: limit conn and limit req reject an overlong key

### DIFF
--- a/limit_conn.t
+++ b/limit_conn.t
@@ -23,7 +23,7 @@ select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http proxy limit_conn limit_req/);
 
-$t->write_file_expand('nginx.conf', <<'EOF')->plan(8);
+$t->write_file_expand('nginx.conf', <<'EOF')->plan(10);
 
 %%TEST_GLOBALS%%
 
@@ -40,6 +40,7 @@ http {
     limit_conn_zone  $binary_remote_addr  zone=zone:1m;
     limit_conn_zone  $binary_remote_addr  zone=zone2:1m;
     limit_conn_zone  $binary_remote_addr  zone=custom:1m;
+    limit_conn_zone  $http_x_key          zone=key:1m;
 
     server {
         listen       127.0.0.1:8081;
@@ -47,6 +48,10 @@ http {
 
         location /w {
             limit_req  zone=req burst=10;
+        }
+
+        location /empty {
+            return 204;
         }
     }
 
@@ -76,6 +81,11 @@ http {
             limit_conn_log_level info;
             limit_conn_status 501;
             limit_conn custom 1;
+        }
+
+        location /key {
+            proxy_pass http://127.0.0.1:8081/empty;
+            limit_conn key 10;
         }
     }
 }
@@ -114,5 +124,29 @@ like($t->read_file('error.log'),
 $s = http_get('/w', start => 1);
 like(http_get('/unlim'), qr/404 Not Found/, 'unlimited passed');
 like(http_get('/'), qr/503 Service/, 'limited rejected');
+
+# a key within the length limit is not rejected, while an overlong key is
+# rejected instead of silently skipping the limit
+
+unlike(http_key('/key', 'short'), qr/^HTTP\/1.. 503 /, 'key passed');
+
+TODO: {
+local $TODO = 'not yet';
+
+like(http_key('/key', 'x' x 300), qr/^HTTP\/1.. 503 /, 'overlong key rejected');
+
+}
+
+###############################################################################
+
+sub http_key {
+	my ($uri, $key) = @_;
+	return http(<<EOF);
+GET $uri HTTP/1.0
+Host: localhost
+X-Key: $key
+
+EOF
+}
 
 ###############################################################################

--- a/limit_req.t
+++ b/limit_req.t
@@ -21,7 +21,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http limit_req/)->plan(6);
+my $t = Test::Nginx->new()->has(qw/http limit_req/)->plan(8);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -38,12 +38,18 @@ http {
     limit_req_zone  $binary_remote_addr  zone=one:1m   rate=2r/s;
     limit_req_zone  $binary_remote_addr  zone=long:1m  rate=2r/s;
     limit_req_zone  $binary_remote_addr  zone=fast:1m  rate=1000r/s;
+    limit_req_zone  $http_x_key          zone=key:1m   rate=1000r/s;
+
+    large_client_header_buffers  4 128k;
 
     server {
         listen       127.0.0.1:8080;
         server_name  localhost;
         location / {
             limit_req    zone=one  burst=1  nodelay;
+        }
+        location /keyreq.html {
+            limit_req    zone=key  burst=100;
         }
         location /status {
             limit_req    zone=one  burst=1  nodelay;
@@ -64,6 +70,7 @@ EOF
 $t->write_file('test1.html', 'XtestX');
 $t->write_file('long.html', "1234567890\n" x (1 << 16));
 $t->write_file('fast.html', 'XtestX');
+$t->write_file('keyreq.html', 'XtestX');
 $t->run();
 
 ###############################################################################
@@ -93,5 +100,30 @@ like(http_get('/test1.html'), qr/^HTTP\/1.. 200 /m, 'rejects not counted');
 http_get('/fast.html');
 select undef, undef, undef, 0.1;
 like(http_get('/fast.html'), qr/^HTTP\/1.. 200 /m, 'negative excess');
+
+# a key within the length limit is not rejected, while an overlong key is
+# rejected instead of silently skipping the limit
+
+unlike(http_key('/keyreq.html', 'short'), qr/^HTTP\/1.. 503 /m, 'key passed');
+
+TODO: {
+local $TODO = 'not yet';
+
+like(http_key('/keyreq.html', 'x' x 65600), qr/^HTTP\/1.. 503 /m,
+	'overlong key rejected');
+
+}
+
+###############################################################################
+
+sub http_key {
+	my ($uri, $key) = @_;
+	return http(<<EOF);
+GET $uri HTTP/1.0
+Host: localhost
+X-Key: $key
+
+EOF
+}
 
 ###############################################################################

--- a/stream_limit_conn.t
+++ b/stream_limit_conn.t
@@ -23,7 +23,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http stream stream_limit_conn/)
-	->plan(8)->write_file_expand('nginx.conf', <<'EOF');
+	->plan(9)->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
 
@@ -37,6 +37,9 @@ stream {
 
     limit_conn_zone  $binary_remote_addr  zone=zone:1m;
     limit_conn_zone  $binary_remote_addr  zone=zone2:1m;
+
+    # a key that always exceeds the 255-byte storable length
+    limit_conn_zone  "$binary_remote_addr aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  zone=longkey:1m;
 
     server {
         listen           127.0.0.1:8080;
@@ -66,6 +69,12 @@ stream {
         listen           127.0.0.1:8083;
         proxy_pass       127.0.0.1:8080;
         limit_conn       zone 1;
+    }
+
+    server {
+        listen           127.0.0.1:8086;
+        proxy_pass       127.0.0.1:8084;
+        limit_conn       longkey 1;
     }
 }
 
@@ -110,6 +119,15 @@ EOF
 
 like(get('127.0.0.1:' . port(8082)), qr/200 OK/, 'passed proxy');
 is(get('127.0.0.1:' . port(8083)), undef, 'rejected proxy');
+
+# an overlong key is rejected instead of silently skipping the limit
+
+TODO: {
+local $TODO = 'not yet';
+
+is(get('127.0.0.1:' . port(8086)), undef, 'overlong key rejected');
+
+}
 
 ###############################################################################
 


### PR DESCRIPTION
Adds cases to `limit_conn.t` and `limit_req.t` verifying that a request whose evaluated key exceeds the storable length (255 bytes for limit_conn, 65535 for limit_req) is rejected with the configured status rather than silently skipping the limit (fail-open).

Uses a header-based key (`$http_x_key`); the overlong-key assertions are TODO-guarded until the corresponding code change is released. A short key is checked to pass as a baseline.

Code PR: nginx/nginx#1583