### PR TITLE
SSL verify partial chain

### DIFF
--- a/mail_imap_ssl_partial_chain.t
+++ b/mail_imap_ssl_partial_chain.t
@@ -1,0 +1,239 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc.
+
+# Tests for nginx mail imap module with ssl_verify_client partial_chain.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use MIME::Base64;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::IMAP;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+local $SIG{PIPE} = 'IGNORE';
+
+my $t = Test::Nginx->new()
+	->has(qw/mail mail_ssl imap http rewrite socket_ssl_sslversion/)
+	->has_daemon('openssl')->plan(9)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+mail {
+    proxy_pass_error_message  on;
+    proxy_timeout  15s;
+    auth_http  http://127.0.0.1:18083/mail/auth;
+    auth_http_pass_client_cert on;
+
+    ssl_certificate_key localhost.key;
+    ssl_certificate localhost.crt;
+
+    server {
+        listen     127.0.0.1:18080 ssl;
+        protocol   imap;
+
+        ssl_verify_client    partial_chain;
+        ssl_client_certificate int.crt;
+    }
+
+    server {
+        listen     127.0.0.1:18081 ssl;
+        protocol   imap;
+
+        ssl_verify_client    on;
+        ssl_client_certificate int.crt;
+    }
+
+    server {
+        listen     127.0.0.1:18082 ssl;
+        protocol   imap;
+
+        ssl_verify_client       partial_chain;
+        ssl_trusted_certificate int.crt;
+    }
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    log_format test '$http_auth_ssl_verify:$http_auth_ssl_subject:'
+                    '$http_auth_pass';
+
+    server {
+        listen       127.0.0.1:18083;
+        server_name  localhost;
+
+        location = /mail/auth {
+            access_log auth.log test;
+
+            add_header Auth-Status OK;
+            add_header Auth-Server 127.0.0.1;
+            add_header Auth-Port 18084;
+            add_header Auth-Wait 1;
+            return 204;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+x509_extensions = myca_extensions
+[ req_distinguished_name ]
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+EOF
+
+my $d = $t->testdir();
+
+$t->write_file('ca.conf', <<EOF);
+[ ca ]
+default_ca = myca
+
+[ myca ]
+new_certs_dir = $d
+database      = $d/certindex
+default_md    = sha256
+policy        = myca_policy
+serial        = $d/certserial
+default_days  = 3
+x509_extensions = client_extensions
+
+[ myca_policy ]
+commonName = supplied
+
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+
+[ client_extensions ]
+basicConstraints = CA:FALSE
+extendedKeyUsage = clientAuth
+EOF
+
+sub openssl {
+	system("$_[0] >>$d/openssl.out 2>&1") == 0
+		or die "openssl command failed: $_[0]\n";
+}
+
+openssl("openssl req -x509 -new "
+	. "-config $d/openssl.conf -subj /CN=localhost/ "
+	. "-out $d/localhost.crt -keyout $d/localhost.key");
+
+openssl("openssl req -x509 -new "
+	. "-config $d/openssl.conf -subj /CN=root/ "
+	. "-out $d/root.crt -keyout $d/root.key");
+
+foreach my $name ('int', 'end') {
+	openssl("openssl req -new "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.csr -keyout $d/$name.key");
+}
+
+openssl("openssl req -x509 -new "
+	. "-config $d/openssl.conf -subj /CN=other/ "
+	. "-out $d/other.crt -keyout $d/other.key");
+
+$t->write_file('certserial', '1000');
+$t->write_file('certindex', '');
+
+openssl("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-extensions myca_extensions "
+	. "-subj /CN=int/ -in $d/int.csr -out $d/int.crt");
+
+openssl("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/int.key -cert $d/int.crt "
+	. "-extensions client_extensions "
+	. "-subj /CN=end/ -in $d/end.csr -out $d/end.crt");
+
+$t->run_daemon(\&Test::Nginx::IMAP::imap_test_daemon, 18084);
+$t->run()->waitforsocket('127.0.0.1:18084');
+
+###############################################################################
+
+my $cred = sub { encode_base64("\0test\@example.com\0$_[0]", '') };
+
+my $s = Test::Nginx::IMAP->new(PeerAddr => '127.0.0.1:18080', SSL => 1);
+$s->check(qr/BYE No required SSL certificate/, 'partial_chain - no cert');
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18080',
+	SSL => 1,
+	SSL_cert_file => "$d/end.crt",
+	SSL_key_file => "$d/end.key"
+);
+$s->ok('partial_chain - leaf cert accepted');
+$s->send('1 AUTHENTICATE PLAIN ' . $cred->("p1"));
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18080',
+	SSL => 1,
+	SSL_cert_file => "$d/other.crt",
+	SSL_key_file => "$d/other.key"
+);
+$s->check(qr/BYE SSL certificate error/, 'partial_chain - unknown cert rejected');
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18081',
+	SSL => 1,
+	SSL_cert_file => "$d/end.crt",
+	SSL_key_file => "$d/end.key"
+);
+$s->check(qr/BYE SSL certificate error/,
+	'on \(control\) - leaf cert rejected without root CA');
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18082',
+	SSL => 1,
+	SSL_cert_file => "$d/end.crt",
+	SSL_key_file => "$d/end.key"
+);
+$s->ok('partial_chain trusted_certificate - leaf cert accepted');
+$s->send('1 AUTHENTICATE PLAIN ' . $cred->("p2"));
+
+$s = Test::Nginx::IMAP->new(PeerAddr => '127.0.0.1:18082', SSL => 1);
+$s->check(qr/BYE No required SSL certificate/,
+	'partial_chain trusted_certificate - no cert');
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18082',
+	SSL => 1,
+	SSL_cert_file => "$d/other.crt",
+	SSL_key_file => "$d/other.key"
+);
+$s->check(qr/BYE SSL certificate error/,
+	'partial_chain trusted_certificate - unknown cert rejected');
+
+$t->stop();
+
+my $f = $t->read_file('auth.log');
+
+like($f, qr!^SUCCESS:(/?CN=end):p1$!m,
+	'partial_chain auth log - leaf cert via client_certificate');
+like($f, qr!^SUCCESS:(/?CN=end):p2$!m,
+	'partial_chain auth log - leaf cert via trusted_certificate');
+
+###############################################################################

--- a/mail_imap_ssl_partial_chain.t
+++ b/mail_imap_ssl_partial_chain.t
@@ -2,7 +2,7 @@
 
 # (C) Nginx, Inc.
 
-# Tests for nginx mail imap module with ssl_verify_client partial_chain.
+# Tests for nginx mail imap module with ssl_verify_partial_chain.
 
 ###############################################################################
 
@@ -28,7 +28,7 @@ local $SIG{PIPE} = 'IGNORE';
 
 my $t = Test::Nginx->new()
 	->has(qw/mail mail_ssl imap http rewrite socket_ssl_sslversion/)
-	->has_daemon('openssl')->plan(9)
+	->has_daemon('openssl')->plan(12)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -51,7 +51,8 @@ mail {
         listen     127.0.0.1:18080 ssl;
         protocol   imap;
 
-        ssl_verify_client    partial_chain;
+        ssl_verify_client    on;
+        ssl_verify_partial_chain on;
         ssl_client_certificate int.crt;
     }
 
@@ -67,8 +68,18 @@ mail {
         listen     127.0.0.1:18082 ssl;
         protocol   imap;
 
-        ssl_verify_client       partial_chain;
+        ssl_verify_client       on;
+        ssl_verify_partial_chain on;
         ssl_trusted_certificate int.crt;
+    }
+
+    server {
+        listen     127.0.0.1:18085 ssl;
+        protocol   imap;
+
+        ssl_verify_client    optional;
+        ssl_verify_partial_chain on;
+        ssl_client_certificate int.crt;
     }
 }
 
@@ -226,6 +237,28 @@ $s = Test::Nginx::IMAP->new(
 );
 $s->check(qr/BYE SSL certificate error/,
 	'partial_chain trusted_certificate - unknown cert rejected');
+
+$s = Test::Nginx::IMAP->new(PeerAddr => '127.0.0.1:18085', SSL => 1);
+$s->ok('partial_chain optional - no cert');
+$s->send('1 AUTHENTICATE PLAIN ' . $cred->("p3"));
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18085',
+	SSL => 1,
+	SSL_cert_file => "$d/end.crt",
+	SSL_key_file => "$d/end.key"
+);
+$s->ok('partial_chain optional - leaf cert accepted');
+$s->send('1 AUTHENTICATE PLAIN ' . $cred->("p4"));
+
+$s = Test::Nginx::IMAP->new(
+	PeerAddr => '127.0.0.1:18085',
+	SSL => 1,
+	SSL_cert_file => "$d/other.crt",
+	SSL_key_file => "$d/other.key"
+);
+$s->check(qr/BYE SSL certificate error/,
+	'partial_chain optional - unknown cert rejected');
 
 $t->stop();
 

--- a/ssl_verify_client_partial_chain.t
+++ b/ssl_verify_client_partial_chain.t
@@ -2,11 +2,11 @@
 
 # (C) Nginx, Inc.
 
-# Tests for http ssl module, ssl_verify_client partial_chain.
+# Tests for http ssl module, ssl_verify_partial_chain.
 #
-# Validates that ssl_verify_client partial_chain accepts a client certificate
-# whose chain terminates at a trusted intermediate CA, without requiring the
-# full chain of trust up to a root CA.
+# Validates that ssl_verify_partial_chain accepts a client certificate whose
+# chain terminates at a trusted intermediate CA, without requiring the full
+# chain of trust up to a root CA.
 
 ###############################################################################
 
@@ -28,7 +28,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http http_ssl socket_ssl/)
-	->has_daemon('openssl')->plan(7);
+	->has_daemon('openssl')->plan(10);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -53,7 +53,8 @@ http {
         listen       127.0.0.1:8080 ssl;
         server_name  localhost;
 
-        ssl_verify_client    partial_chain;
+        ssl_verify_client    on;
+        ssl_verify_partial_chain on;
         ssl_client_certificate int.crt;
     }
 
@@ -72,8 +73,18 @@ http {
         listen       127.0.0.1:8082 ssl;
         server_name  localhost;
 
-        ssl_verify_client       partial_chain;
+        ssl_verify_client       on;
+        ssl_verify_partial_chain on;
         ssl_trusted_certificate int.crt;
+    }
+
+    server {
+        listen       127.0.0.1:8083 ssl;
+        server_name  localhost;
+
+        ssl_verify_client    optional;
+        ssl_verify_partial_chain on;
+        ssl_client_certificate int.crt;
     }
 }
 
@@ -173,7 +184,7 @@ $t->run();
 
 # --- partial_chain via ssl_client_certificate ---
 
-# no cert: partial_chain requires a cert (behaves like "on")
+# no cert: partial_chain with verify_client on requires a cert
 like(get(8080), qr/400 Bad Request/, 'partial_chain - no cert');
 
 # leaf cert signed by trusted intermediate: should be accepted
@@ -194,13 +205,21 @@ like(get(8081, 'end'), qr/400 Bad Request/,
 like(get(8082, 'end'), qr/SUCCESS/,
 	'partial_chain trusted_certificate - leaf cert accepted');
 
-# no cert: partial_chain requires a cert
+# no cert: partial_chain with verify_client on requires a cert
 like(get(8082), qr/400 Bad Request/,
 	'partial_chain trusted_certificate - no cert');
 
 # unrelated cert: should be rejected
 like(get(8082, 'other'), qr/400 Bad Request/,
 	'partial_chain trusted_certificate - unknown cert rejected');
+
+# --- partial_chain with optional client verification ---
+
+like(get(8083), qr/NONE/, 'partial_chain optional - no cert');
+like(get(8083, 'end'), qr/SUCCESS/,
+	'partial_chain optional - leaf cert accepted');
+like(get(8083, 'other'), qr/400 Bad Request/,
+	'partial_chain optional - unknown cert rejected');
 
 ###############################################################################
 
@@ -218,4 +237,3 @@ sub get {
 }
 
 ###############################################################################
-

--- a/ssl_verify_client_partial_chain.t
+++ b/ssl_verify_client_partial_chain.t
@@ -1,0 +1,221 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc.
+
+# Tests for http ssl module, ssl_verify_client partial_chain.
+#
+# Validates that ssl_verify_client partial_chain accepts a client certificate
+# whose chain terminates at a trusted intermediate CA, without requiring the
+# full chain of trust up to a root CA.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use Socket qw/ CRLF /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx qw/ :DEFAULT /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl socket_ssl/)
+	->has_daemon('openssl')->plan(7);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_certificate     localhost.crt;
+    ssl_certificate_key localhost.key;
+
+    add_header X-Verify $ssl_client_verify always;
+
+    # partial_chain: accepts leaf cert signed by trusted intermediate,
+    # root CA is not in the bundle and not required
+    server {
+        listen       127.0.0.1:8080 ssl;
+        server_name  localhost;
+
+        ssl_verify_client    partial_chain;
+        ssl_client_certificate int.crt;
+    }
+
+    # control: same intermediate-only bundle but regular "on" mode;
+    # leaf cert must fail because root CA is absent from the store
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  localhost;
+
+        ssl_verify_client    on;
+        ssl_client_certificate int.crt;
+    }
+
+    # partial_chain via ssl_trusted_certificate (not ssl_client_certificate)
+    server {
+        listen       127.0.0.1:8082 ssl;
+        server_name  localhost;
+
+        ssl_verify_client       partial_chain;
+        ssl_trusted_certificate int.crt;
+    }
+}
+
+EOF
+
+my $d = $t->testdir();
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+x509_extensions = myca_extensions
+[ req_distinguished_name ]
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+EOF
+
+$t->write_file('ca.conf', <<EOF);
+[ ca ]
+default_ca = myca
+
+[ myca ]
+new_certs_dir = $d
+database      = $d/certindex
+default_md    = sha256
+policy        = myca_policy
+serial        = $d/certserial
+default_days  = 3
+x509_extensions = client_extensions
+
+[ myca_policy ]
+commonName = supplied
+
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+
+[ client_extensions ]
+basicConstraints = CA:FALSE
+extendedKeyUsage = clientAuth
+EOF
+
+# self-signed server certificate
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=localhost/ "
+	. "-out $d/localhost.crt -keyout $d/localhost.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create localhost certificate: $!\n";
+
+# root CA (self-signed) - intentionally NOT added to nginx trust store
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=root/ "
+	. "-out $d/root.crt -keyout $d/root.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create root certificate: $!\n";
+
+# intermediate CA and leaf CSRs
+foreach my $name ('int', 'end') {
+	system('openssl req -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.csr -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create CSR for $name: $!\n";
+}
+
+# unrelated self-signed cert (not in any chain)
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=other/ "
+	. "-out $d/other.crt -keyout $d/other.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create other certificate: $!\n";
+
+$t->write_file('certserial', '1000');
+$t->write_file('certindex', '');
+
+# intermediate CA signed by root
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-extensions myca_extensions "
+	. "-subj /CN=int/ -in $d/int.csr -out $d/int.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign intermediate certificate: $!\n";
+
+# leaf cert signed by intermediate (has clientAuth extension)
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/int.key -cert $d/int.crt "
+	. "-extensions client_extensions "
+	. "-subj /CN=end/ -in $d/end.csr -out $d/end.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign end certificate: $!\n";
+
+$t->write_file('t', '');
+
+$t->run();
+
+###############################################################################
+
+# --- partial_chain via ssl_client_certificate ---
+
+# no cert: partial_chain requires a cert (behaves like "on")
+like(get(8080), qr/400 Bad Request/, 'partial_chain - no cert');
+
+# leaf cert signed by trusted intermediate: should be accepted
+like(get(8080, 'end'), qr/SUCCESS/, 'partial_chain - leaf cert accepted');
+
+# unrelated self-signed cert: should be rejected
+like(get(8080, 'other'), qr/400 Bad Request/, 'partial_chain - unknown cert rejected');
+
+# --- control: regular "on" with same intermediate-only bundle ---
+
+# leaf cert fails with regular "on" because root CA is not trusted
+like(get(8081, 'end'), qr/400 Bad Request/,
+	'on (control) - leaf cert rejected without root CA');
+
+# --- partial_chain via ssl_trusted_certificate ---
+
+# leaf cert signed by trusted intermediate: should be accepted
+like(get(8082, 'end'), qr/SUCCESS/,
+	'partial_chain trusted_certificate - leaf cert accepted');
+
+# no cert: partial_chain requires a cert
+like(get(8082), qr/400 Bad Request/,
+	'partial_chain trusted_certificate - no cert');
+
+# unrelated cert: should be rejected
+like(get(8082, 'other'), qr/400 Bad Request/,
+	'partial_chain trusted_certificate - unknown cert rejected');
+
+###############################################################################
+
+sub get {
+	my ($port, $cert) = @_;
+	http_get(
+		'/t',
+		PeerAddr => '127.0.0.1:' . port($port),
+		SSL => 1,
+		$cert ? (
+		SSL_cert_file => "$d/$cert.crt",
+		SSL_key_file  => "$d/$cert.key",
+		) : ()
+	);
+}
+
+###############################################################################
+

--- a/stream_ssl_verify_client_partial_chain.t
+++ b/stream_ssl_verify_client_partial_chain.t
@@ -1,0 +1,208 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc.
+
+# Tests for stream ssl module, ssl_verify_client partial_chain.
+#
+# Validates that ssl_verify_client partial_chain accepts a client certificate
+# whose chain terminates at a trusted intermediate CA, without requiring the
+# full chain of trust up to a root CA.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_ssl stream_return socket_ssl/)
+	->has_daemon('openssl')->plan(6);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    ssl_certificate     localhost.crt;
+    ssl_certificate_key localhost.key;
+
+    # partial_chain: accepts leaf cert signed by trusted intermediate
+    server {
+        listen  127.0.0.1:8080 ssl;
+        return  $ssl_client_verify:$ssl_client_s_dn;
+
+        ssl_verify_client    partial_chain;
+        ssl_client_certificate int.crt;
+    }
+
+    # control: same intermediate-only bundle, regular "on" mode
+    server {
+        listen  127.0.0.1:8081 ssl;
+        return  $ssl_client_verify:$ssl_client_s_dn;
+
+        ssl_verify_client    on;
+        ssl_client_certificate int.crt;
+    }
+
+    # partial_chain via ssl_trusted_certificate
+    server {
+        listen  127.0.0.1:8082 ssl;
+        return  $ssl_client_verify:$ssl_client_s_dn;
+
+        ssl_verify_client       partial_chain;
+        ssl_trusted_certificate int.crt;
+    }
+}
+
+EOF
+
+my $d = $t->testdir();
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+x509_extensions = myca_extensions
+[ req_distinguished_name ]
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+EOF
+
+$t->write_file('ca.conf', <<EOF);
+[ ca ]
+default_ca = myca
+
+[ myca ]
+new_certs_dir = $d
+database      = $d/certindex
+default_md    = sha256
+policy        = myca_policy
+serial        = $d/certserial
+default_days  = 3
+x509_extensions = client_extensions
+
+[ myca_policy ]
+commonName = supplied
+
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+
+[ client_extensions ]
+basicConstraints = CA:FALSE
+extendedKeyUsage = clientAuth
+EOF
+
+# server certificate
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=localhost/ "
+	. "-out $d/localhost.crt -keyout $d/localhost.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create localhost certificate: $!\n";
+
+# root CA (not trusted by nginx)
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=root/ "
+	. "-out $d/root.crt -keyout $d/root.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create root certificate: $!\n";
+
+foreach my $name ('int', 'end') {
+	system('openssl req -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.csr -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create CSR for $name: $!\n";
+}
+
+# unrelated cert
+system('openssl req -x509 -new '
+	. "-config $d/openssl.conf -subj /CN=other/ "
+	. "-out $d/other.crt -keyout $d/other.key "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create other certificate: $!\n";
+
+$t->write_file('certserial', '1000');
+$t->write_file('certindex', '');
+
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-extensions myca_extensions "
+	. "-subj /CN=int/ -in $d/int.csr -out $d/int.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign intermediate certificate: $!\n";
+
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/int.key -cert $d/int.crt "
+	. "-extensions client_extensions "
+	. "-subj /CN=end/ -in $d/end.csr -out $d/end.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign end certificate: $!\n";
+
+$t->run();
+
+###############################################################################
+
+# --- partial_chain via ssl_client_certificate ---
+
+# no cert: connection is dropped (cert required like "on")
+is(get(8080), '', 'partial_chain - no cert');
+
+# leaf cert signed by trusted intermediate: accepted
+like(get(8080, 'end'), qr/SUCCESS/, 'partial_chain - leaf cert accepted');
+
+# unrelated cert: connection is dropped
+is(get(8080, 'other'), '', 'partial_chain - unknown cert rejected');
+
+# --- control: regular "on" with same intermediate-only bundle ---
+
+# leaf cert rejected because root CA is absent from the store
+is(get(8081, 'end'), '', 'on (control) - leaf cert rejected without root CA');
+
+# --- partial_chain via ssl_trusted_certificate ---
+
+# leaf cert accepted
+like(get(8082, 'end'), qr/SUCCESS/,
+	'partial_chain trusted_certificate - leaf cert accepted');
+
+# unrelated cert: connection is dropped
+is(get(8082, 'other'), '',
+	'partial_chain trusted_certificate - unknown cert rejected');
+
+###############################################################################
+
+sub get {
+	my ($port, $cert) = @_;
+
+	my $s = stream(
+		PeerAddr => '127.0.0.1:' . port($port),
+		SSL => 1,
+		$cert ? (
+		SSL_cert_file => "$d/$cert.crt",
+		SSL_key_file  => "$d/$cert.key",
+		) : ()
+	);
+
+	return $s->read();
+}
+
+###############################################################################
+

--- a/stream_ssl_verify_client_partial_chain.t
+++ b/stream_ssl_verify_client_partial_chain.t
@@ -2,11 +2,11 @@
 
 # (C) Nginx, Inc.
 
-# Tests for stream ssl module, ssl_verify_client partial_chain.
+# Tests for stream ssl module, ssl_verify_partial_chain.
 #
-# Validates that ssl_verify_client partial_chain accepts a client certificate
-# whose chain terminates at a trusted intermediate CA, without requiring the
-# full chain of trust up to a root CA.
+# Validates that ssl_verify_partial_chain accepts a client certificate whose
+# chain terminates at a trusted intermediate CA, without requiring the full
+# chain of trust up to a root CA.
 
 ###############################################################################
 
@@ -27,7 +27,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/stream stream_ssl stream_return socket_ssl/)
-	->has_daemon('openssl')->plan(6);
+	->has_daemon('openssl')->plan(9);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -49,7 +49,8 @@ stream {
         listen  127.0.0.1:8080 ssl;
         return  $ssl_client_verify:$ssl_client_s_dn;
 
-        ssl_verify_client    partial_chain;
+        ssl_verify_client    on;
+        ssl_verify_partial_chain on;
         ssl_client_certificate int.crt;
     }
 
@@ -67,8 +68,18 @@ stream {
         listen  127.0.0.1:8082 ssl;
         return  $ssl_client_verify:$ssl_client_s_dn;
 
-        ssl_verify_client       partial_chain;
+        ssl_verify_client       on;
+        ssl_verify_partial_chain on;
         ssl_trusted_certificate int.crt;
+    }
+
+    server {
+        listen  127.0.0.1:8083 ssl;
+        return  $ssl_client_verify:$ssl_client_s_dn;
+
+        ssl_verify_client    optional;
+        ssl_verify_partial_chain on;
+        ssl_client_certificate int.crt;
     }
 }
 
@@ -163,7 +174,7 @@ $t->run();
 
 # --- partial_chain via ssl_client_certificate ---
 
-# no cert: connection is dropped (cert required like "on")
+# no cert: connection is dropped (cert required with verify_client on)
 is(get(8080), '', 'partial_chain - no cert');
 
 # leaf cert signed by trusted intermediate: accepted
@@ -187,6 +198,12 @@ like(get(8082, 'end'), qr/SUCCESS/,
 is(get(8082, 'other'), '',
 	'partial_chain trusted_certificate - unknown cert rejected');
 
+# --- partial_chain with optional client verification ---
+
+like(get(8083), qr/NONE:/, 'partial_chain optional - no cert');
+like(get(8083, 'end'), qr/SUCCESS/, 'partial_chain optional - leaf cert accepted');
+is(get(8083, 'other'), '', 'partial_chain optional - unknown cert rejected');
+
 ###############################################################################
 
 sub get {
@@ -205,4 +222,3 @@ sub get {
 }
 
 ###############################################################################
-


### PR DESCRIPTION
## Problem

There was no dedicated regression coverage for the new
`ssl_verify_client partial_chain` mode.

Without targeted tests, it would be easy to regress the intended
behavior in one module while the others continue to pass.

## Solution

Add focused regression tests for `ssl_verify_client partial_chain` in:

- HTTP
- stream
- mail (IMAP)

The tests build a small CA hierarchy with a self-signed root, an
intermediate signed by that root, and a leaf client certificate signed by
the intermediate. The root is intentionally not trusted by nginx, so the
tests specifically verify that `partial_chain` accepts the leaf
certificate when the trusted intermediate is present.

The tests also verify that:

- an unrelated certificate is rejected;
- the control case with `ssl_verify_client on` still rejects the same
  leaf certificate when only the intermediate is trusted;
- missing client certificates are rejected where `partial_chain` is
  expected to behave like `on`.

## Testing

Validated with:

```sh
TEST_NGINX_BINARY=/path/to/nginx/objs/nginx prove -v \
    ssl_verify_client_partial_chain.t \
    stream_ssl_verify_client_partial_chain.t \
    mail_imap_ssl_partial_chain.t
```

Result: all 28 tests passed.

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** N/A

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the contributing guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows project standards and contains only
  relevant changes

## Release Notes

Added regression coverage for the new `ssl_verify_client partial_chain`
mode in HTTP, stream, and mail.
