### PR TITLE
Tests: $body_bytes_sent with early hints

### DIFF
--- a/proxy_early_hints_bytes.t
+++ b/proxy_early_hints_bytes.t
@@ -1,0 +1,141 @@
+#!/usr/bin/perl
+
+# (C) Sepuri Sai Krishna
+
+# Tests for $body_bytes_sent with HTTP 103 Early Hints.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::HTTP2;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_v2 proxy/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    log_format bytes  '$uri $server_protocol $body_bytes_sent';
+
+    access_log %%TESTDIR%%/bytes.log bytes;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        http2 on;
+        early_hints 1;
+
+        location / {
+            proxy_pass http://127.0.0.1:8081;
+            proxy_http_version 1.1;
+
+            location /off/ {
+                proxy_pass http://127.0.0.1:8081/;
+                early_hints 0;
+            }
+        }
+    }
+}
+
+EOF
+
+$t->try_run('no early_hints')->plan(4);
+
+$t->run_daemon(\&http_daemon);
+$t->waitforsocket('127.0.0.1:' . port(8081));
+
+###############################################################################
+
+# bytes of a 103 response are header bytes, and are not to be counted
+# in $body_bytes_sent
+
+like(get('/'), qr/103.*200 OK.*SEE-THIS/s, 'early hints');
+
+get('/off/');
+
+my $s = Test::Nginx::HTTP2->new();
+$s->read(all => [{ sid => $s->new_stream(), fin => 1 }]);
+
+$t->stop();
+
+my $log = $t->read_file('bytes.log');
+
+like($log, qr!^/ HTTP/1\.1 8$!m, 'body bytes sent');
+like($log, qr!^/off/ HTTP/1\.1 8$!m, 'body bytes sent - no early hints');
+like($log, qr!^/ HTTP/2\.0 8$!m, 'body bytes sent - http2');
+
+###############################################################################
+
+sub get {
+	my ($uri) = @_;
+	http(<<EOF);
+GET $uri HTTP/1.1
+Host: localhost
+Connection: close
+
+EOF
+}
+
+sub http_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $headers = '';
+
+		while (<$client>) {
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		next if $headers eq '';
+
+		print $client <<'EOF';
+HTTP/1.1 103
+Link: </style.css>; rel=preload; as=style
+
+EOF
+
+		print $client <<'EOF';
+HTTP/1.1 200 OK
+Content-Length: 8
+Connection: close
+
+EOF
+
+		print $client 'SEE-THIS';
+	}
+}
+
+###############################################################################


### PR DESCRIPTION
### Proposed changes

Adds `proxy_early_hints_bytes.t`.

Companion to nginx/nginx#1606 — this test does not
pass until that change lands.

Bytes written for a 103 (Early Hints) response are header bytes and should not
be counted in `$body_bytes_sent`. The upstream returns an 8-byte body, so
`$body_bytes_sent` must be 8 whether or not early hints are sent.

Covers HTTP/1.1 with `early_hints` on, HTTP/1.1 with `early_hints` off as a
control, and HTTP/2 — HTTP/2 already accumulates `r->header_size` correctly,
so it guards against a regression in the other direction.

Against current nginx master:

```
#   Failed test 'body bytes sent'
#   at proxy_early_hints_bytes.t line 85.
#                   '/ HTTP/1.1 79
# /off/ HTTP/1.1 8
# / HTTP/2.0 8
# '
#     doesn't match '(?^m:^/ HTTP/1\.1 8$)'
# Looks like you failed 1 test of 6.
```

The 79 is 8 body bytes plus the 71-byte 103 response. The two control cases
pass unchanged, which is what pins the bug to HTTP/1.x with early hints
enabled.

With the fix applied:

```
proxy_early_hints_bytes.t .... ok
All tests successful.
```

The test is not vacuous: the first assertion checks a 103 was actually
emitted, so it cannot pass by early hints silently not firing.

Needs only `http_v2` and `proxy`, so no leg of it is skipped on a default
build.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
