### PR TITLE
Tests: PROXY protocol with mixed address families

### DIFF
--- a/stream_proxy_protocol.t
+++ b/stream_proxy_protocol.t
@@ -26,7 +26,7 @@ use Test::Nginx::Stream qw/ stream /;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/stream/)->plan(2)
+my $t = Test::Nginx->new()->has(qw/stream stream_realip/)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -51,12 +51,29 @@ stream {
         proxy_pass      127.0.0.1:8081;
         proxy_protocol  off;
     }
+
+    server {
+        listen          127.0.0.1:8083 proxy_protocol;
+        set_real_ip_from 127.0.0.1;
+        proxy_pass      127.0.0.1:8081;
+    }
+
+    server {
+        listen          127.0.0.1:8084;
+        proxy_pass      [::1]:%%PORT_8085%%;
+    }
+
+    server {
+        listen          [::1]:%%PORT_8085%% proxy_protocol;
+        set_real_ip_from ::1;
+        proxy_pass      127.0.0.1:8081;
+    }
 }
 
 EOF
 
 $t->run_daemon(\&stream_daemon);
-$t->run();
+$t->try_run('no inet6 support')->plan(4);
 $t->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
@@ -68,6 +85,13 @@ my $sp = $s->sockport();
 is($data, "PROXY TCP4 127.0.0.1 127.0.0.1 $sp $dp${CRLF}close", 'protocol on');
 
 is(stream('127.0.0.1:' . port(8082))->io('close'), 'close', 'protocol off');
+
+is(stream('127.0.0.1:' . port(8083))->io(
+	"PROXY TCP6 2001:db8::1 2001:db8::2 1234 5678${CRLF}close"),
+	"PROXY UNKNOWN${CRLF}close", 'protocol mixed address families');
+
+is(stream('127.0.0.1:' . port(8084))->io('close'),
+	"PROXY UNKNOWN${CRLF}close", 'protocol reverse mixed address families');
 
 ###############################################################################
 

--- a/stream_proxy_protocol.t
+++ b/stream_proxy_protocol.t
@@ -59,6 +59,11 @@ stream {
     }
 
     server {
+        listen          127.0.0.1:8086 proxy_protocol;
+        proxy_pass      127.0.0.1:8081;
+    }
+
+    server {
         listen          127.0.0.1:8084;
         proxy_pass      [::1]:%%PORT_8085%%;
     }
@@ -73,7 +78,7 @@ stream {
 EOF
 
 $t->run_daemon(\&stream_daemon);
-$t->try_run('no inet6 support')->plan(4);
+$t->try_run('no inet6 support')->plan(5);
 $t->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
@@ -88,10 +93,23 @@ is(stream('127.0.0.1:' . port(8082))->io('close'), 'close', 'protocol off');
 
 is(stream('127.0.0.1:' . port(8083))->io(
 	"PROXY TCP6 2001:db8::1 2001:db8::2 1234 5678${CRLF}close"),
-	"PROXY UNKNOWN${CRLF}close", 'protocol mixed address families');
+	"PROXY TCP6 2001:db8::1 2001:db8::2 1234 5678${CRLF}close",
+	'protocol incoming tuple');
 
-is(stream('127.0.0.1:' . port(8084))->io('close'),
-	"PROXY UNKNOWN${CRLF}close", 'protocol reverse mixed address families');
+my $p = pack("N3C", 0x0D0A0D0A, 0x000D0A51, 0x5549540A, 0x21);
+my $tcp4 = $p . pack("CnN2n2", 0x11, 12, 0xc0000201, 0xc0000202,
+	1234, 5678);
+
+is(stream('127.0.0.1:' . port(8086))->io($tcp4 . 'close'),
+	"PROXY TCP4 192.0.2.1 192.0.2.2 1234 5678${CRLF}close",
+	'protocol v2 incoming tuple');
+
+my $dp4 = port(8084);
+my $s4 = stream('127.0.0.1:' . $dp4);
+my $data4 = $s4->io('close');
+my $sp4 = $s4->sockport();
+is($data4, "PROXY TCP4 127.0.0.1 127.0.0.1 $sp4 $dp4${CRLF}close",
+	'protocol incoming tuple through ipv6 hop');
 
 ###############################################################################
 


### PR DESCRIPTION
Tests the core fix in nginx/nginx#1614 for nginx/nginx#1609.

The test sends an IPv6 PROXY address over an IPv4 accepted socket and also exercises the reverse direction through an IPv4-to-IPv6 proxy chain. After realip replaces the remote address, the source and destination families differ; nginx must emit `PROXY UNKNOWN` rather than an invalid mixed `TCP4` or `TCP6` header.

Against nginx master, the first new assertion fails with:

```
PROXY TCP6 2001:db8::1 127.0.0.1 1234 8083
```

Against nginx/nginx#1614, all related tests pass:

```
stream_proxy_protocol.t        6/6
stream_proxy_protocol_ipv6.t   4/4
stream_realip.t               10/10
mail_proxy_protocol.t         10/10
Result: PASS
```