### PR TITLE
Tests: Expect RST_STREAM for "trailer only" responses with content-length

### DIFF
--- a/grpc.t
+++ b/grpc.t
@@ -24,7 +24,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http rewrite http_v2 grpc/)
-	->has(qw/upstream_keepalive/)->plan(147);
+	->has(qw/upstream_keepalive/)->plan(148);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -387,6 +387,19 @@ $frames = $f->{http_err}();
 is($frame->{flags}, 5, 'grpc error - HEADERS flags');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
 ok(!$frame, 'grpc error - no DATA frame');
+
+# trailers only with non-zero content-length
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.4');
+
+$f->{http_start}('/SayHello');
+$f->{data}('Hello');
+$frames = $f->{http_err}(cl => 5);
+($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
+ok($frame, 'grpc error - trailers only with content-length');
+
+}
 
 # malformed response body length not equal to content-length
 
@@ -835,7 +848,8 @@ reused:
 		return $s->read(all => [{ sid => $csid, fin => 1 }]);
 	};
 	$f->{http_err} = sub {
-		$c->new_stream({ headers => [
+		my (%extra) = @_;
+		my $h = [
 			{ name => ':status', value => '200', mode => 0 },
 			{ name => 'content-type', value => 'application/grpc',
 				mode => 1, huff => 1 },
@@ -843,8 +857,14 @@ reused:
 				mode => 2, huff => 1 },
 			{ name => 'grpc-message', value => 'unknown service',
 				mode => 2, huff => 1 },
-		]}, $sid);
+		];
+		push @$h, { name => 'content-length',
+			value => $extra{cl}, mode => 1, huff => 1 }
+				if $extra{cl};
+		$c->new_stream({ headers => $h }, $sid);
 
+		return $s->read(all => [{ type => 'RST_STREAM' }])
+			if $extra{cl};
 		return $s->read(all => [{ fin => 1 }]);
 	};
 	$f->{http_err_rst} = sub {


### PR DESCRIPTION
### Proposed changes

Adds test coverage for "trailer-only" responses from upstream to receive RST_STREAM on client_sdie. Test case sends a "trailers only" response with content-length: 5 but no DATA frames, and asserts that RST_STREAM is received. 

This PR supports issue https://github.com/nginx/nginx/issues/1568 and corresponing code fix PR https://github.com/nginx/nginx/pull/1591

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
