### PR TITLE
Tests: zero `WINDOW_UPDATE` from HTTP/2 upstream

### DIFF
--- a/grpc.t
+++ b/grpc.t
@@ -24,7 +24,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http rewrite http_v2 grpc/)
-	->has(qw/upstream_keepalive/)->plan(148);
+	->has(qw/upstream_keepalive/)->plan(150);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -704,6 +704,31 @@ ok($frame->{headers}{'grpc-status'}, 'keepalive 3 - grpc error, rst');
 $frames = $f->{http_start}('/KeepAlive', reuse => 1);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 ok($frame, 'keepalive 3 - connection reused');
+
+undef $f;
+$f = grpc();
+
+# zero WINDOW_UPDATE increments
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.4');
+
+$f->{http_start}('/');
+$f->{update_sid}(0);
+$frames = $f->{http_end}();
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}{':status'}, 502, 'zero window update - stream');
+
+undef $f;
+$f = grpc();
+
+$f->{http_start}('/');
+$f->{update}(0);
+$frames = $f->{http_end}();
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}{':status'}, 502, 'zero window update - connection');
+
+}
 
 undef $f;
 $f = grpc();

--- a/proxy_h2.t
+++ b/proxy_h2.t
@@ -102,7 +102,7 @@ $t->write_file('stub', '');
 $t->run_daemon(\&http_daemon);
 $t->waitforsocket('127.0.0.1:' . port(8081));
 
-$t->try_run('no proxy_http_version 2')->plan(28);
+$t->try_run('no proxy_http_version 2')->plan(30);
 
 ###############################################################################
 
@@ -116,6 +116,16 @@ like(http_get('/var?b=127.0.0.1:' . port(8081) . '/'), qr/SEE-THIS/,
 like(http_get('/var?b=u/'), qr/SEE-THIS/, 'proxy with variables to upstream');
 
 like(http_get('/timeout'), qr/200 OK/, 'proxy connect timeout');
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.4');
+
+like(http_get('/window-zero-stream'), qr/502 Bad Gateway/,
+	'zero window update - stream');
+like(http_get('/window-zero-connection'), qr/502 Bad Gateway/,
+	'zero window update - connection');
+
+}
 
 my $re = qr/(\d\.\d{3})/;
 my $p0 = port(8081);
@@ -219,6 +229,14 @@ sub http_daemon {
 				{ name => ':status', value => '200' },
 			]}, $sid);
 			$c->h2_body('SEE-THIS');
+
+		} elsif ($uri =~ /^\/window-zero-(stream|connection)$/) {
+			$c->start_chain();
+			$c->h2_window(0, $1 eq 'stream' ? $sid : 0);
+			$c->new_stream({ headers => [
+				{ name => ':status', value => '200' },
+			]}, $sid);
+			$c->send_chain();
 
 		} elsif ($uri eq '/multi') {
 			$c->new_stream({ body_more => 1, headers => [


### PR DESCRIPTION
 ### Proposed changes

  Adds regression coverage for zero-increment `WINDOW_UPDATE` frames
  received from HTTP/2 upstream servers.

  The tests exercise both stream- and connection-scoped frames in the
  HTTP/2 proxy and gRPC upstream implementations. In each case, the
  backend sends the invalid `WINDOW_UPDATE` followed by an otherwise valid
  successful response, and the test asserts that nginx rejects the
  response with `502 Bad Gateway`.

  Without the companion nginx fix, all four assertions fail because nginx
  accepts the invalid frame and returns `200 OK`.


  ### Testing

 Companion source PR: [nginx/nginx#1622](https://github.com/nginx/nginx/pull/1622)

  Tested against the unmodified source:

  ```text
  Failed test 'zero window update - stream'
  got: '200'
  expected: '502'

  Failed test 'zero window update - connection'
  got: '200'
  expected: '502'
```

  Tested with the companion source fix:

```text
  grpc.t ................... ok
  proxy_h2_body_discard.t .. ok
  All tests successful.
  Files=2, Tests=161
  Result: PASS
```