### PR TITLE
Tests: HTTP/3 reserved frame type on a request stream

### DIFF
--- a/h3_request_body.t
+++ b/h3_request_body.t
@@ -24,7 +24,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http http_v3 proxy cryptx/)
-	->has_daemon('openssl')->plan(30);
+	->has_daemon('openssl')->plan(34);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -135,6 +135,49 @@ is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTMOREDATA',
 	'request body in multiple frames separately');
 is($frame->{headers}->{'x-length'}, 12,
 	'request body in multiple frames separately - content length');
+
+# reserved frame with a payload after the body
+
+$s = Test::Nginx::HTTP3->new();
+$sid = $s->new_stream({ path => '/proxy/t.html', body_more => 1,
+	body => 'TEST' });
+$s->h3_frame(0x1f * 42 + 0x21, 'grease', $sid);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 200, 'reserved frame - status');
+is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST',
+	'reserved frame - body');
+
+# reserved frame between two DATA frames
+
+$s = Test::Nginx::HTTP3->new();
+$sid = $s->new_stream({ body_more => 1, headers => [
+	{ name => ':method', value => 'GET' },
+	{ name => ':scheme', value => 'http' },
+	{ name => ':path', value => '/proxy/t.html' },
+	{ name => ':authority', value => 'localhost' },
+	{ name => 'content-length', value => '8' }]});
+$s->h3_body('TEST', $sid, { body_more => 1 });
+$s->h3_frame(0x1f * 42 + 0x21, 'grease', $sid, { body_more => 1 });
+$s->h3_body('MORE', $sid);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTMORE',
+	'reserved frame between data - body');
+
+# reserved frame with an empty payload
+
+$s = Test::Nginx::HTTP3->new();
+$sid = $s->new_stream({ path => '/proxy/t.html', body_more => 1,
+	body => 'TEST' });
+$s->h3_frame(0x1f * 42 + 0x21, '', $sid);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST',
+	'reserved frame empty - body');
 
 # request body with an empty DATA frame
 

--- a/lib/Test/Nginx/HTTP3.pm
+++ b/lib/Test/Nginx/HTTP3.pm
@@ -507,6 +507,19 @@ sub pack_body {
 	$buf .= $body;
 }
 
+sub h3_frame {
+	my ($self, $type, $body, $sid, $extra) = @_;
+
+	$body = '' unless defined $body;
+	my $buf = build_int($type) . build_int(length($body)) . $body;
+
+	my $offset = $extra->{offset} || $self->{streams}{$sid}{sent};
+
+	$self->{streams}{$sid}{sent} += length($buf);
+	$self->raw_write($self->build_stream($buf,
+		start => $extra->{body_more}, sid => $sid, offset => $offset));
+}
+
 sub h3_max_data {
 	my ($self, $val, $stream) = @_;
 


### PR DESCRIPTION
### Proposed changes

This provides regression tests against the bug presented in https://github.com/nginx/nginx/pull/1624 by using reserved frames.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation. (n/a)