### PR TITLE
Tests: chunk size overflow detection

### DIFF
--- a/body_chunked.t
+++ b/body_chunked.t
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(18);
+my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(19);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -161,6 +161,25 @@ like(
 	),
 	qr/400 Bad/, 'runaway chunk discard'
 );
+
+# an overflowing chunk size is detected when it is split from the rest, and does
+# not wait for more data
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.4');
+
+like(
+	http(
+		'POST / HTTP/1.1' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'Connection: close' . CRLF
+		. 'Transfer-Encoding: chunked' . CRLF . CRLF
+		. '7ffffffffffffff7'
+	),
+	qr/400 Bad/, 'chunk size overflow'
+);
+
+}
 
 # proxy_next_upstream
 


### PR DESCRIPTION
Regression test for nginx/nginx#1625 (e419e28c9, "Fixed overflow detection in
chunked parser"), which corrected the headroom in the chunk size guard from
`NGX_MAX_OFF_T_VALUE - 5` to `- 9` after f405ef11f (1.29.4) made the largest
addition to `ctx->size` be `2 /* CRLF */ + ctx->size + 7` = size + 9.

The test sends a chunk size of `7ffffffffffffff7` split from the rest of the
data, so that the size is validated when it is parsed rather than after more
data arrives, and expects it to be rejected with 400.

Verified against builds with and without the fix: it passes with the corrected
guard and fails with the old `- 5` guard.

The fix is not in a release yet (latest tag is 1.31.3), so the check is guarded
with `has_version('1.31.4')` and is skipped as TODO on older versions.