### PR TITLE
[codex] Tests: cover client_max_body_size on chunked discard path

### DIFF
--- a/body_chunked.t
+++ b/body_chunked.t
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(18);
+my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(21);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -71,6 +71,10 @@ http {
             proxy_pass http://127.0.0.1:8081;
         }
         location /discard {
+            return 200 "TEST\n";
+        }
+        location /discard-large {
+            client_max_body_size 1k;
             return 200 "TEST\n";
         }
         location /next {
@@ -133,6 +137,13 @@ like(http_get_body('/discard', '0123456789', '0123456789' x 128,
 like(http_get_body('/discard', '0123456789' x 128, '0123456789' x 512,
 	'0123456789', 'foobar'), qr/(TEST.*){4}/ms,
 	'chunked body discard 2');
+
+like(http_chunked_body('/discard-large', 'A' x 512, 'B' x 512),
+	qr/ 200 /, 'chunked body discard at limit');
+like(http_chunked_body('/discard-large', 'A' x 1025),
+	qr/ 413 /, 'chunked body discard too large');
+like(http_chunked_body('/discard-large', 'A' x 512, 'B' x 512, 'C'),
+	qr/ 413 /, 'chunked body discard too large in multiple chunks');
 
 # invalid chunks
 
@@ -215,6 +226,21 @@ sub http_get_body {
 		. "Transfer-Encoding: chunked" . CRLF . CRLF
 		. sprintf("%x", length $last) . CRLF
 		. $last . CRLF
+		. "0" . CRLF . CRLF
+	);
+}
+
+sub http_chunked_body {
+	my ($uri, @chunks) = @_;
+
+	return http(
+		"POST $uri HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Connection: close" . CRLF
+		. "Transfer-Encoding: chunked" . CRLF . CRLF
+		. join('', map {
+			sprintf("%x", length $_) . CRLF . $_ . CRLF
+		} @chunks)
 		. "0" . CRLF . CRLF
 	);
 }


### PR DESCRIPTION
## Summary

Add regression coverage for nginx issue #1522 and companion source PR
https://github.com/nginx/nginx/pull/1688.

The tests cover a discarded chunked request body:

- exactly at `client_max_body_size` across multiple chunks;
- over the limit in one chunk;
- over the limit cumulatively across multiple chunks.

## Red-to-green result

Against nginx baseline `3f6f7824d4e2eb1ac37dec76683d525ac0ff521c`, the
two over-limit assertions fail because nginx returns 200 instead of 413.

Against the companion source patch, all 23 assertions in `body_chunked.t`
pass. The broader `body.t`, `body_chunked.t`, and `http_keepalive.t` run also
passes all 63 tests, with two pre-existing TODO assertions remaining TODO.

Related issue: https://github.com/nginx/nginx/issues/1522
