### PR TITLE
Tests: improved predicate location tests

### DIFF
--- a/http_location_predicate.t
+++ b/http_location_predicate.t
@@ -128,6 +128,10 @@ http {
                 return 204;
             }
         }
+
+        location /redirect {
+            rewrite ^ /x?a=1? last;
+        }
     }
 }
 
@@ -163,13 +167,14 @@ is(get('/regex?b=1'), 'regex b', 'predicate in regex location');
 
 is(get('/named?a=1'), 'named', 'named over predicate');
 
-is(get('/x?c=1'), 'c', 'predicate with nested locations');
 is(get('/c/exact?c=1&d=1'), 'c exact', 'exact in predicate location');
 is(get('/c/prefix?c=1'), 'c prefix', 'prefix in predicate location');
 is(get('/c/prefix?c=1&d=1'), 'c d', 'predicate over prefix in predicate');
 is(get('/c/regex?c=1&d=1'), 'c regex', 'regex over predicate in predicate');
 is(get('/x?c=1&d=1'), 'c d', 'predicate in predicate location');
 is(get('/c/if?c=2'), 'c if', 'if in predicate location');
+
+is(get('/redirect'), 'a', 'predicate after internal redirect');
 
 ###############################################################################
 

--- a/http_location_predicate_extra.t
+++ b/http_location_predicate_extra.t
@@ -3,7 +3,7 @@
 # (C) Eugene Grebenschikov
 # (C) Nginx, Inc.
 
-# Tests for predicate locations, proxy_pass, root, and alias directives.
+# Tests for predicate locations, additional tests.
 
 ###############################################################################
 
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http rewrite proxy/);
+my $t = Test::Nginx->new()->has(qw/http rewrite proxy map/);
 
 plan(skip_all => 'not yet') unless $t->has_version('1.31.5');
 
@@ -37,6 +37,15 @@ events {
 
 http {
     %%TEST_GLOBALS_HTTP%%
+
+    map $uri $mapped {
+        /mapped  1;
+    }
+
+    map $uri $volatile {
+        volatile;
+        /volatile  1;
+    }
 
     server {
         listen       127.0.0.1:8080;
@@ -65,6 +74,30 @@ http {
             }
             return 204;
         }
+
+        location $arg_dir {
+            location /dir/ {
+                proxy_pass http://127.0.0.1:8081;
+            }
+        }
+
+        location /redirect/mapped {
+            rewrite ^ /mapped last;
+        }
+
+        location /redirect/volatile {
+            rewrite ^ /volatile last;
+        }
+
+        location $mapped {
+            add_header X-Location "mapped";
+            return 204;
+        }
+
+        location $volatile {
+            add_header X-Location "volatile";
+            return 204;
+        }
     }
 
     server {
@@ -83,7 +116,7 @@ EOF
 mkdir($t->testdir() . '/html');
 $t->write_file('html/t', 'SEE-THIS');
 
-$t->run()->plan(5);
+$t->run()->plan(11);
 
 ###############################################################################
 
@@ -99,5 +132,19 @@ like(http_get('/t?alias_try=1'), qr/SEE-THIS/,
 
 like(http_get('/sub/t?alias_nest=1'), qr/SEE-THIS/,
 	'alias in nested prefix under predicate location');
+
+like(http_get('/dir/?dir=1'), qr/X-Location: proxied/,
+	'slash prefix in predicate location');
+
+like(http_get('/dir?dir=1'), qr/301 Moved/,
+	'auto redirect in predicate location');
+
+like(http_get('/mapped'), qr/X-Location: mapped/, 'map predicate');
+like(http_get('/volatile'), qr/X-Location: volatile/, 'volatile map predicate');
+
+like(http_get('/redirect/mapped'), qr/404 Not Found/,
+	'map predicate cached before redirect');
+like(http_get('/redirect/volatile'), qr/X-Location: volatile/,
+	'volatile map after redirect');
 
 ###############################################################################


### PR DESCRIPTION
### Proposed changes

This is a follow-up of discussion in #102 .

Test coverage for predicate locations is already good (~86%), but it can be improved slightly (up to ~90%), along with a few cosmetic tweaks.

1. Renamed `_misc.t` to `_extra.t`.  `misc` was the only suffix of its kind in the suite, the established convention is `_extra` (eg, `h2_request_body_extra.t`, `memcached_fake_extra.t`, `proxy_chunked_extra.t`). The file header was also corrected.

2. Removed a duplicate: the 'predicate with nested locations' test was an exact copy of 'predicate last'.

3. Auto-redirect. This was discussed during the review of nginx/nginx#1633: a slash prefix inside a predicate was failing to trigger a 301 redirect. The merged code propagates `NGX_DONE`, but `gcov` showed 0% branch coverage.

4. Predicate re-evaluation after an internal redirect. All existing checks involving `$arg_*` lacked redirects. 5 tests were added using a `map` predicate: a non cacheable variable is re-eval, a cached map is not, and a `volatile` one is

