### PR TITLE
Tests: backport guard-clause fix tests from freenginx

### DIFF
--- a/body_chunked.t
+++ b/body_chunked.t
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(18);
+my $t = Test::Nginx->new()->has(qw/http proxy rewrite/)->plan(24);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -68,6 +68,7 @@ http {
         }
         location /large {
             client_max_body_size 1k;
+            client_body_buffer_size 2k;
             proxy_pass http://127.0.0.1:8081;
         }
         location /discard {
@@ -119,6 +120,8 @@ like(http_get_body('/single', '0123456789' x 128),
 	qr/X-Body: (0123456789){128}\x0d?$/ms, 'body in single buffer');
 
 like(http_get_body('/large', '0123456789' x 128), qr/ 413 /, 'body too large');
+like(http_get_body('/large', 'X' x 1024), qr/ 200 /, 'body exact limit');
+like(http_get_body('/large', 'X' x 1025), qr/ 413 /, 'body just above limit');
 
 # pipelined requests
 
@@ -161,6 +164,66 @@ like(
 	),
 	qr/400 Bad/, 'runaway chunk discard'
 );
+
+# chunk extensions and trailers
+
+like(
+	http(
+		'GET /large HTTP/1.1' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'Connection: close' . CRLF
+		. 'Transfer-Encoding: chunked' . CRLF . CRLF
+		. ('1; foo' . CRLF . 'X' . CRLF) x 16
+		. '0' . CRLF . CRLF
+	),
+	qr/ 200 /, 'chunk extensions'
+);
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.5');
+
+like(
+	http(
+		'GET /large HTTP/1.1' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'Connection: close' . CRLF
+		. 'Transfer-Encoding: chunked' . CRLF . CRLF
+		. ('1; foo' . CRLF . 'X' . CRLF) x 512
+		. '0' . CRLF . CRLF
+	),
+	qr/ 413 /, 'too many chunk extensions'
+);
+
+}
+
+like(
+	http(
+		'GET /large HTTP/1.1' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'Connection: close' . CRLF
+		. 'Transfer-Encoding: chunked' . CRLF . CRLF
+		. '1' . CRLF . 'X' . CRLF
+		. '0' . CRLF . ('X-Trailer: foo' . CRLF) x 16 . CRLF
+	),
+	qr/ 200 /, 'trailers'
+);
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.5');
+
+like(
+	http(
+		'GET /large HTTP/1.1' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'Connection: close' . CRLF
+		. 'Transfer-Encoding: chunked' . CRLF . CRLF
+		. '1' . CRLF . 'X' . CRLF
+		. '0' . CRLF . ('X-Trailer: foo' . CRLF) x 512 . CRLF
+	),
+	qr/ 413 /, 'too many trailers'
+);
+
+}
 
 # proxy_next_upstream
 

--- a/mail_imap.t
+++ b/mail_imap.t
@@ -96,7 +96,7 @@ http {
 EOF
 
 $t->run_daemon(\&Test::Nginx::IMAP::imap_test_daemon);
-$t->run()->plan(31);
+$t->run()->plan(32);
 
 $t->waitforsocket('127.0.0.1:' . port(8144));
 
@@ -200,6 +200,23 @@ $s->read();
 
 $s->send('1 AUTHENTICATE EXTERNAL ' . encode_base64('test@example.com', ''));
 $s->ok('auth external with username');
+
+# auth external after failed plain
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.5');
+
+$s = Test::Nginx::IMAP->new();
+$s->read();
+
+$s->send('1 AUTHENTICATE PLAIN '
+	. encode_base64("\0test\@example.com\0bad", ''));
+$s->read();
+
+$s->send('1 AUTHENTICATE EXTERNAL ' . encode_base64('test@example.com', ''));
+$s->ok('auth external after plain');
+
+}
 
 # quoted strings
 

--- a/proxy_ssl_certificate_vars.t
+++ b/proxy_ssl_certificate_vars.t
@@ -67,6 +67,20 @@ http {
             proxy_ssl_certificate $arg_cert;
             proxy_ssl_certificate_key $arg_cert;
         }
+
+        location /complex/ {
+            proxy_ssl_certificate $arg_cert.example.com.crt;
+            proxy_ssl_certificate_key $arg_cert.example.com.key;
+            proxy_ssl_password_file password;
+
+            location /complex/1 {
+                proxy_pass https://127.0.0.1:8082/;
+            }
+
+            location /complex/2 {
+                proxy_pass https://127.0.0.1:8082/;
+            }
+        }
     }
 
     server {
@@ -138,7 +152,7 @@ sleep 1 if $^O eq 'MSWin32';
 $t->write_file('password', '3.example.com');
 $t->write_file('index.html', '');
 
-$t->run()->plan(5);
+$t->run()->plan(7);
 
 ###############################################################################
 
@@ -160,5 +174,17 @@ like(http_get('/optimized?cert=3'),
 
 like(http_get('/none'),
 	qr/X-Verify: NONE/ms, 'variable - no certificate');
+
+TODO: {
+todo_skip 'leaves coredump', 2 unless $t->has_version('1.27.5')
+	or $ENV{TEST_NGINX_UNSAFE};
+
+like(http_get('/complex/1?cert=3'),
+	qr/X-Verify: SUCCESS/ms, 'variable - inherited encrypted key 1st');
+
+like(http_get('/complex/2?cert=3'),
+	qr/X-Verify: SUCCESS/ms, 'variable - inherited encrypted key 2nd');
+
+}
 
 ###############################################################################

--- a/ssi_stub.t
+++ b/ssi_stub.t
@@ -1,0 +1,108 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+
+# Tests for nginx ssi module, stub output.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy ssi/)->plan(4)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            ssi on;
+        }
+
+        location = /empty {
+            # static
+        }
+
+        location = /error404 {
+            # static 404
+        }
+
+        location = /proxy404 {
+            proxy_pass http://127.0.0.1:8081;
+            proxy_intercept_errors on;
+            error_page 404 /error404;
+        }
+
+        location = /not_empty {
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+    }
+}
+
+EOF
+
+$t->write_file('empty.html',
+	'<!--#block name="fallback" -->fallback<!--#endblock -->' .
+	':<!--#include virtual="/empty" stub="fallback" -->:');
+
+$t->write_file('error.html',
+	'<!--#block name="fallback" -->fallback<!--#endblock -->' .
+	':<!--#include virtual="/error404" stub="fallback" -->:');
+
+$t->write_file('proxy_error.html',
+	'<!--#block name="fallback" -->fallback<!--#endblock -->' .
+	':<!--#include virtual="/proxy404" stub="fallback" -->:');
+
+$t->write_file('postponed.html',
+	'<!--#block name="fallback" -->fallback<!--#endblock -->' .
+	':<!--#include virtual="/not_empty" -->' .
+	':<!--#include virtual="/empty" stub="fallback" -->:');
+
+$t->write_file('empty', '');
+$t->write_file('not_empty', 'not empty');
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/empty.html'), qr/:fallback:/, 'ssi stub empty');
+like(http_get('/error.html'), qr/:fallback:/, 'ssi stub error');
+like(http_get('/proxy_error.html'), qr/:fallback:/, 'ssi stub proxied error');
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.31.5');
+
+like(http_get('/postponed.html'), qr/:not empty:fallback:/s,
+	'ssi stub postponed');
+
+}
+
+###############################################################################


### PR DESCRIPTION
## Summary

Companion test backports for nginx/nginx#1696 (backport of guard-clause
fixes from freenginx). Four freenginx-tests changesets by Maxim Dounin are
backported, exercising fixes carried by that PR: the request body chunk
extension/trailer limit, IMAP EXTERNAL auth password clearing, SSI stub
output, and proxy SSL password inheritance.

Each commit preserves the original author, date, and commit message, and
carries an `Origin:` trailer linking the freenginx-tests changeset, the
backporter's `Signed-off-by:`, and a `Co-authored-by:` trailer (all four
patches required adaptation, documented per commit).

## Commits (in application order)

| # | Commit | Description |
|---|--------|-------------|
| 1 | [`d54443f`](https://github.com/dekobon/nginx-tests/commit/d54443fcf1b9a1bb45178ecaf1c3c43e4ae1d48a) | Tests: tests for request body chunked extensions and trailers. |
| 2 | [`88c5b78`](https://github.com/dekobon/nginx-tests/commit/88c5b78fdda71c9919e3ed4bfa04cae867d410e9) | Tests: added test that EXTERNAL mail auth clears old password. |
| 3 | [`2385b14`](https://github.com/dekobon/nginx-tests/commit/2385b1447c9084163d4ae26aa5bda6f1db6ce7eb) | Tests: SSI include stub tests. |
| 4 | [`48f2a8d`](https://github.com/dekobon/nginx-tests/commit/48f2a8d9bd5d39e48079dfd38a13258512c83f19) | Tests: tests for proxy_ssl_password_file issue. |

## Deviations from the freenginx originals

- **Version guards retargeted, not removed.** The fork's version guards were
  translated to mainline versioning rather than dropped, so the suite keeps
  working against nginx builds that do not carry the fixes. The three tests
  exercising fixes from nginx/nginx#1696 are guarded with
  `has_version('1.31.5')` — they enforce normally on that branch and
  TODO-fail on older nginx instead of failing hard. The proxy_ssl
  inherited-key tests are guarded with `has_version('1.27.5')` (the released
  version carrying nginx's own `merge_ssl_passwords` fix) plus the usual
  `TEST_NGINX_UNSAFE` opt-out, since on older versions those requests
  segfault a worker and leave a coredump; the guard also covers both
  inherited-key requests, where freenginx guarded only the second.
- Test plan counts and surrounding context differ from freenginx-tests in
  places where the files have drifted (documented in each commit body).

## Companion changes

The code fixes exercised by the first three test files are in
nginx/nginx#1696, on the matching `cherry/freenginx-guard-clauses` branch of
[`dekobon/nginx`](https://github.com/dekobon/nginx). The proxy_ssl test needs
no companion change — mainline fixed that issue in 1.27.5.

## Testing

All four files pass against the nginx/nginx#1696 branch build (75/75, with
SSL, HTTP/2, mail, and stream modules enabled) and degrade to TODO/skip
against builds without the fixes (verified against a stock master build).
